### PR TITLE
feat: add map display with route visualization

### DIFF
--- a/index.html
+++ b/index.html
@@ -24,6 +24,8 @@
       <p id="error-display" hidden></p>
 
       <button id="clear-btn" type="button" hidden>Clear route</button>
+
+      <div id="map-container"></div>
     </div>
     <script type="module" src="/src/main.ts"></script>
   </body>

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,11 @@
     "": {
       "name": "fuelspot",
       "version": "0.0.0",
+      "dependencies": {
+        "leaflet": "^1.9.4"
+      },
       "devDependencies": {
+        "@types/leaflet": "^1.9.21",
         "happy-dom": "^20.8.4",
         "typescript": "~5.9.3",
         "vite": "^8.0.0",
@@ -397,6 +401,23 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/geojson": {
+      "version": "7946.0.16",
+      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.16.tgz",
+      "integrity": "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/leaflet": {
+      "version": "1.9.21",
+      "resolved": "https://registry.npmjs.org/@types/leaflet/-/leaflet-1.9.21.tgz",
+      "integrity": "sha512-TbAd9DaPGSnzp6QvtYngntMZgcRk+igFELwR2N99XZn7RXUdKgsXMR+28bUO0rPsWp8MIu/f47luLIQuSLYv/w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/geojson": "*"
+      }
+    },
     "node_modules/@types/node": {
       "version": "25.5.0",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-25.5.0.tgz",
@@ -664,6 +685,12 @@
       "engines": {
         "node": ">=20.0.0"
       }
+    },
+    "node_modules/leaflet": {
+      "version": "1.9.4",
+      "resolved": "https://registry.npmjs.org/leaflet/-/leaflet-1.9.4.tgz",
+      "integrity": "sha512-nxS1ynzJOmOlHp+iL3FyWqK89GtNL8U8rvlMOsQdTTssxZwCXh8N2NB3GDQOL+YR3XnWyZAxwQixURb+FA74PA==",
+      "license": "BSD-2-Clause"
     },
     "node_modules/lightningcss": {
       "version": "1.32.0",

--- a/package.json
+++ b/package.json
@@ -11,9 +11,13 @@
     "test:run": "vitest run"
   },
   "devDependencies": {
+    "@types/leaflet": "^1.9.21",
     "happy-dom": "^20.8.4",
     "typescript": "~5.9.3",
     "vite": "^8.0.0",
     "vitest": "^4.1.0"
+  },
+  "dependencies": {
+    "leaflet": "^1.9.4"
   }
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,4 +1,24 @@
+import 'leaflet/dist/leaflet.css';
 import './style.css';
+import * as L from 'leaflet';
+import markerIcon2x from 'leaflet/dist/images/marker-icon-2x.png';
+import markerIcon from 'leaflet/dist/images/marker-icon.png';
+import markerShadow from 'leaflet/dist/images/marker-shadow.png';
+import { setDefaultFactory } from './route-map';
 import { initUpload } from './upload';
+
+// Fix Leaflet default marker icons broken by Vite bundling
+L.Icon.Default.mergeOptions({
+  iconUrl: markerIcon,
+  iconRetinaUrl: markerIcon2x,
+  shadowUrl: markerShadow,
+});
+
+setDefaultFactory({
+  map: (container, options) => L.map(container, options),
+  tileLayer: (url, options) => L.tileLayer(url, options),
+  polyline: (latlngs, options) => L.polyline(latlngs, options),
+  marker: (latlng, options) => L.marker(latlng, options),
+});
 
 initUpload();

--- a/src/route-map.test.ts
+++ b/src/route-map.test.ts
@@ -1,0 +1,210 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { LeafletFactory, RouteMapHandle } from './route-map';
+import { initRouteMap } from './route-map';
+import type { ParsedRoute } from './gpx-parser';
+
+function makeRoute(
+  points: Array<{ lat: number; lng: number }>,
+  name: string | null = 'Test',
+): ParsedRoute {
+  let cumulative = 0;
+  return {
+    name,
+    totalDistance: 0,
+    points: points.map((p, i) => {
+      if (i > 0) cumulative += 1000;
+      return { lat: p.lat, lng: p.lng, cumulativeDistance: cumulative };
+    }),
+  };
+}
+
+function createMockFactory() {
+  const mockMap = {
+    fitBounds: vi.fn(),
+    setView: vi.fn(),
+    remove: vi.fn(),
+  };
+  const mockTileLayer = { addTo: vi.fn().mockReturnThis() };
+
+  const polylines: Array<{ addTo: ReturnType<typeof vi.fn>; remove: ReturnType<typeof vi.fn>; getBounds: ReturnType<typeof vi.fn> }> = [];
+  const markers: Array<{ addTo: ReturnType<typeof vi.fn>; remove: ReturnType<typeof vi.fn> }> = [];
+
+  const factory: LeafletFactory = {
+    map: vi.fn(() => mockMap) as unknown as LeafletFactory['map'],
+    tileLayer: vi.fn(
+      () => mockTileLayer,
+    ) as unknown as LeafletFactory['tileLayer'],
+    polyline: vi.fn(() => {
+      const p = {
+        addTo: vi.fn().mockReturnThis(),
+        remove: vi.fn(),
+        getBounds: vi.fn(() => 'mockBounds'),
+      };
+      polylines.push(p);
+      return p;
+    }) as unknown as LeafletFactory['polyline'],
+    marker: vi.fn(() => {
+      const m = { addTo: vi.fn().mockReturnThis(), remove: vi.fn() };
+      markers.push(m);
+      return m;
+    }) as unknown as LeafletFactory['marker'],
+  };
+
+  return { factory, mockMap, mockTileLayer, polylines, markers };
+}
+
+describe('route-map', () => {
+  let container: HTMLElement;
+  let mocks: ReturnType<typeof createMockFactory>;
+  let handle: RouteMapHandle;
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    mocks = createMockFactory();
+    handle = initRouteMap(container, mocks.factory);
+  });
+
+  // Cycle 1: Module shape
+  it('returns an object with showRoute, clear, destroy', () => {
+    expect(typeof handle.showRoute).toBe('function');
+    expect(typeof handle.clear).toBe('function');
+    expect(typeof handle.destroy).toBe('function');
+  });
+
+  // Cycle 2: Map initialization
+  it('calls factory.map once on init', () => {
+    expect(mocks.factory.map).toHaveBeenCalledOnce();
+    const call = vi.mocked(mocks.factory.map).mock.calls[0];
+    expect(call[0]).toBeInstanceOf(HTMLElement);
+    expect(call[1]).toMatchObject({ center: [0, 0], zoom: 2 });
+  });
+
+  // Cycle 3: Tile layer
+  it('creates tile layer with OSM URL and adds to map', () => {
+    expect(mocks.factory.tileLayer).toHaveBeenCalledOnce();
+    const call = vi.mocked(mocks.factory.tileLayer).mock.calls[0];
+    expect(call[0]).toContain('openstreetmap.org');
+    expect(mocks.mockTileLayer.addTo).toHaveBeenCalledWith(mocks.mockMap);
+  });
+
+  // Cycle 4: Polyline from route points
+  it('creates polyline from route points and adds to map', () => {
+    const route = makeRoute([
+      { lat: 50, lng: 20 },
+      { lat: 50.1, lng: 20.1 },
+      { lat: 50.2, lng: 20.2 },
+    ]);
+    handle.showRoute(route);
+
+    expect(mocks.factory.polyline).toHaveBeenCalledOnce();
+    const call = vi.mocked(mocks.factory.polyline).mock.calls[0];
+    expect(call[0]).toEqual([
+      [50, 20],
+      [50.1, 20.1],
+      [50.2, 20.2],
+    ]);
+    expect(mocks.polylines[0].addTo).toHaveBeenCalledWith(mocks.mockMap);
+  });
+
+  // Cycle 5: Start and finish markers
+  it('creates start and finish markers with titles', () => {
+    const route = makeRoute([
+      { lat: 50, lng: 20 },
+      { lat: 51, lng: 21 },
+    ]);
+    handle.showRoute(route);
+
+    expect(mocks.factory.marker).toHaveBeenCalledTimes(2);
+    const calls = vi.mocked(mocks.factory.marker).mock.calls;
+    expect(calls[0][0]).toEqual([50, 20]);
+    expect(calls[0][1]).toMatchObject({ title: 'Start' });
+    expect(calls[1][0]).toEqual([51, 21]);
+    expect(calls[1][1]).toMatchObject({ title: 'Finish' });
+    expect(mocks.markers).toHaveLength(2);
+    expect(mocks.markers[0].addTo).toHaveBeenCalledWith(mocks.mockMap);
+    expect(mocks.markers[1].addTo).toHaveBeenCalledWith(mocks.mockMap);
+  });
+
+  // Cycle 6: Auto-zoom to fit route
+  it('calls fitBounds after showRoute', () => {
+    const route = makeRoute([
+      { lat: 50, lng: 20 },
+      { lat: 51, lng: 21 },
+    ]);
+    handle.showRoute(route);
+
+    expect(mocks.mockMap.fitBounds).toHaveBeenCalledWith('mockBounds', {
+      padding: [20, 20],
+    });
+  });
+
+  // Cycle 7: Re-showing clears previous layers
+  it('removes previous layers when showRoute called again', () => {
+    const route1 = makeRoute([
+      { lat: 50, lng: 20 },
+      { lat: 51, lng: 21 },
+    ]);
+    handle.showRoute(route1);
+    expect(mocks.polylines[0].remove).not.toHaveBeenCalled();
+    expect(mocks.markers[0].remove).not.toHaveBeenCalled();
+    expect(mocks.markers[1].remove).not.toHaveBeenCalled();
+
+    const route2 = makeRoute([
+      { lat: 52, lng: 22 },
+      { lat: 53, lng: 23 },
+    ]);
+    handle.showRoute(route2);
+    expect(mocks.polylines[0].remove).toHaveBeenCalledOnce();
+    expect(mocks.markers[0].remove).toHaveBeenCalledOnce();
+    expect(mocks.markers[1].remove).toHaveBeenCalledOnce();
+  });
+
+  // Cycle 8: clear() removes layers and resets view
+  it('clear removes layers and resets view', () => {
+    const route = makeRoute([
+      { lat: 50, lng: 20 },
+      { lat: 51, lng: 21 },
+    ]);
+    handle.showRoute(route);
+    handle.clear();
+
+    expect(mocks.polylines[0].remove).toHaveBeenCalled();
+    expect(mocks.markers[0].remove).toHaveBeenCalled();
+    expect(mocks.markers[1].remove).toHaveBeenCalled();
+    expect(mocks.mockMap.setView).toHaveBeenCalledWith([0, 0], 2);
+  });
+
+  // Cycle 9: destroy() removes the map
+  it('destroy calls map.remove', () => {
+    handle.destroy();
+    expect(mocks.mockMap.remove).toHaveBeenCalledOnce();
+  });
+
+  // Cycle 10: Single-point route edge case
+  it('handles single-point route with one marker and no polyline', () => {
+    const route = makeRoute([{ lat: 50, lng: 20 }]);
+    handle.showRoute(route);
+
+    expect(mocks.factory.polyline).not.toHaveBeenCalled();
+    expect(mocks.factory.marker).toHaveBeenCalledOnce();
+    expect(mocks.mockMap.setView).toHaveBeenCalledWith([50, 20], 14);
+  });
+
+  // Cycle 11: Placeholder when no route
+  it('shows placeholder initially, hides after showRoute, shows after clear', () => {
+    const placeholder = container.querySelector('.map-placeholder') as HTMLElement;
+    expect(placeholder).not.toBeNull();
+    expect(placeholder.hidden).toBe(false);
+    expect(placeholder.textContent).toContain('Upload a GPX file');
+
+    const route = makeRoute([
+      { lat: 50, lng: 20 },
+      { lat: 51, lng: 21 },
+    ]);
+    handle.showRoute(route);
+    expect(placeholder.hidden).toBe(true);
+
+    handle.clear();
+    expect(placeholder.hidden).toBe(false);
+  });
+});

--- a/src/route-map.ts
+++ b/src/route-map.ts
@@ -1,0 +1,128 @@
+import type { ParsedRoute } from './gpx-parser';
+import type * as L from 'leaflet';
+
+export interface RouteMapHandle {
+  showRoute(route: ParsedRoute): void;
+  clear(): void;
+  destroy(): void;
+}
+
+export interface LeafletFactory {
+  map(container: HTMLElement, options?: L.MapOptions): L.Map;
+  tileLayer(urlTemplate: string, options?: L.TileLayerOptions): L.TileLayer;
+  polyline(
+    latlngs: L.LatLngExpression[],
+    options?: L.PolylineOptions,
+  ): L.Polyline;
+  marker(latlng: L.LatLngExpression, options?: L.MarkerOptions): L.Marker;
+}
+
+const DEFAULT_CENTER: L.LatLngExpression = [0, 0];
+const DEFAULT_ZOOM = 2;
+const PLACEHOLDER_TEXT = 'Upload a GPX file to see your route on the map';
+
+export function initRouteMap(
+  container: HTMLElement,
+  factory?: LeafletFactory,
+): RouteMapHandle {
+  const placeholder = document.createElement('p');
+  placeholder.className = 'map-placeholder';
+  placeholder.textContent = PLACEHOLDER_TEXT;
+  container.appendChild(placeholder);
+
+  const mapDiv = document.createElement('div');
+  mapDiv.className = 'map-inner';
+  container.appendChild(mapDiv);
+
+  const leaflet = factory ?? getDefaultFactory();
+  const map = leaflet.map(mapDiv, { center: DEFAULT_CENTER, zoom: DEFAULT_ZOOM });
+
+  leaflet
+    .tileLayer('https://tile.openstreetmap.org/{z}/{x}/{y}.png', {
+      attribution:
+        '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors',
+      maxZoom: 19,
+    })
+    .addTo(map);
+
+  let currentPolyline: L.Polyline | null = null;
+  let currentMarkers: L.Marker[] = [];
+
+  function removeLayers(): void {
+    if (currentPolyline) {
+      currentPolyline.remove();
+      currentPolyline = null;
+    }
+    for (const m of currentMarkers) {
+      m.remove();
+    }
+    currentMarkers = [];
+  }
+
+  function showRoute(route: ParsedRoute): void {
+    removeLayers();
+    placeholder.hidden = true;
+    mapDiv.hidden = false;
+
+    const latlngs: L.LatLngExpression[] = route.points.map(
+      (p) => [p.lat, p.lng] as [number, number],
+    );
+
+    if (route.points.length > 1) {
+      currentPolyline = leaflet
+        .polyline(latlngs, { color: '#2563eb', weight: 4 })
+        .addTo(map);
+    }
+
+    if (route.points.length >= 1) {
+      const first = route.points[0];
+      const startMarker = leaflet
+        .marker([first.lat, first.lng], { title: 'Start' })
+        .addTo(map);
+      currentMarkers.push(startMarker);
+    }
+
+    if (route.points.length > 1) {
+      const last = route.points[route.points.length - 1];
+      const finishMarker = leaflet
+        .marker([last.lat, last.lng], { title: 'Finish' })
+        .addTo(map);
+      currentMarkers.push(finishMarker);
+    }
+
+    if (route.points.length > 1 && currentPolyline) {
+      map.fitBounds(currentPolyline.getBounds(), { padding: [20, 20] });
+    } else if (route.points.length === 1) {
+      map.setView([route.points[0].lat, route.points[0].lng], 14);
+    }
+  }
+
+  function clear(): void {
+    removeLayers();
+    map.setView(DEFAULT_CENTER, DEFAULT_ZOOM);
+    placeholder.hidden = false;
+    mapDiv.hidden = true;
+  }
+
+  function destroy(): void {
+    map.remove();
+  }
+
+  // Initial state: placeholder visible, map hidden
+  mapDiv.hidden = true;
+
+  return { showRoute, clear, destroy };
+}
+
+let defaultFactory: LeafletFactory | undefined;
+
+export function setDefaultFactory(f: LeafletFactory): void {
+  defaultFactory = f;
+}
+
+function getDefaultFactory(): LeafletFactory {
+  if (defaultFactory) return defaultFactory;
+  throw new Error(
+    'No LeafletFactory provided. Call setDefaultFactory() or pass factory to initRouteMap().',
+  );
+}

--- a/src/style.css
+++ b/src/style.css
@@ -95,3 +95,23 @@ h1 {
 #clear-btn:active {
   background: #f3f4f6;
 }
+
+#map-container {
+  margin-top: 1rem;
+  width: 100%;
+  border-radius: 0.5rem;
+  overflow: hidden;
+}
+
+.map-inner {
+  width: 100%;
+  height: 300px;
+}
+
+.map-placeholder {
+  padding: 2rem 1rem;
+  color: #999;
+  font-size: 0.9rem;
+  background: #f3f4f6;
+  border-radius: 0.5rem;
+}

--- a/src/upload.test.ts
+++ b/src/upload.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { initUpload } from './upload';
+import { MINIMAL_2_TRKPT } from './test-fixtures/gpx-samples';
+
+function setupDOM(): void {
+  document.body.innerHTML = `
+    <div id="app">
+      <label for="gpx-input" class="upload-label">
+        Upload GPX file
+        <input type="file" id="gpx-input" accept=".gpx" />
+      </label>
+      <section id="route-stats" hidden>
+        <h2 id="route-name"></h2>
+        <p id="point-count"></p>
+        <p id="route-distance"></p>
+      </section>
+      <p id="error-display" hidden></p>
+      <button id="clear-btn" type="button" hidden>Clear route</button>
+      <div id="map-container"></div>
+    </div>
+  `;
+}
+
+function simulateFileUpload(content: string): void {
+  const fileInput = document.getElementById('gpx-input') as HTMLInputElement;
+  const file = new File([content], 'test.gpx', { type: 'application/gpx+xml' });
+
+  // Mock the files property
+  Object.defineProperty(fileInput, 'files', {
+    value: [file],
+    writable: false,
+    configurable: true,
+  });
+
+  fileInput.dispatchEvent(new Event('change'));
+}
+
+async function flushFileReader(): Promise<void> {
+  // Allow FileReader.onload to fire
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  await new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+// Mock route-map module
+vi.mock('./route-map', () => {
+  const showRoute = vi.fn();
+  const clear = vi.fn();
+  const destroy = vi.fn();
+  return {
+    initRouteMap: vi.fn(() => ({ showRoute, clear, destroy })),
+    setDefaultFactory: vi.fn(),
+  };
+});
+
+describe('upload integration with map', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    setupDOM();
+    vi.clearAllMocks();
+  });
+
+  // Cycle 12: upload.ts creates map on init
+  it('initializes map on #map-container', async () => {
+    const { initRouteMap } = await import('./route-map');
+    initUpload();
+
+    expect(initRouteMap).toHaveBeenCalledOnce();
+    const call = vi.mocked(initRouteMap).mock.calls[0];
+    expect(call[0]).toBe(document.getElementById('map-container'));
+  });
+
+  // Cycle 13: File upload shows route on map
+  it('calls showRoute on map after file upload', async () => {
+    const { initRouteMap } = await import('./route-map');
+    initUpload();
+    const handle = vi.mocked(initRouteMap).mock.results[0].value;
+
+    simulateFileUpload(MINIMAL_2_TRKPT);
+    await flushFileReader();
+
+    expect(handle.showRoute).toHaveBeenCalledOnce();
+    expect(handle.showRoute).toHaveBeenCalledWith(
+      expect.objectContaining({ points: expect.any(Array) }),
+    );
+  });
+
+  // Cycle 14: Clear button clears map
+  it('calls clear on map when clear button clicked', async () => {
+    const { initRouteMap } = await import('./route-map');
+    initUpload();
+    const handle = vi.mocked(initRouteMap).mock.results[0].value;
+
+    simulateFileUpload(MINIMAL_2_TRKPT);
+    await flushFileReader();
+
+    const clearBtn = document.getElementById('clear-btn') as HTMLButtonElement;
+    clearBtn.click();
+
+    expect(handle.clear).toHaveBeenCalledOnce();
+  });
+
+  // Cycle 15: localStorage route shown on map at init
+  it('shows route from localStorage on init', async () => {
+    localStorage.setItem('fuelspot-gpx', MINIMAL_2_TRKPT);
+    const { initRouteMap } = await import('./route-map');
+    initUpload();
+    const handle = vi.mocked(initRouteMap).mock.results[0].value;
+
+    expect(handle.showRoute).toHaveBeenCalledOnce();
+  });
+});

--- a/src/upload.ts
+++ b/src/upload.ts
@@ -1,5 +1,6 @@
 import { parseGPX } from './gpx-parser';
 import type { ParsedRoute } from './gpx-parser';
+import { initRouteMap } from './route-map';
 
 const STORAGE_KEY = 'fuelspot-gpx';
 
@@ -11,6 +12,9 @@ export function initUpload(): void {
   const routeName = document.getElementById('route-name') as HTMLElement;
   const pointCount = document.getElementById('point-count') as HTMLElement;
   const routeDistance = document.getElementById('route-distance') as HTMLElement;
+  const mapContainer = document.getElementById('map-container') as HTMLElement;
+
+  const mapHandle = initRouteMap(mapContainer);
 
   function showRoute(route: ParsedRoute): void {
     routeName.textContent = route.name ?? 'Unnamed route';
@@ -19,6 +23,7 @@ export function initUpload(): void {
     statsSection.hidden = false;
     errorSection.hidden = true;
     clearBtn.hidden = false;
+    mapHandle.showRoute(route);
   }
 
   function showError(message: string): void {
@@ -32,6 +37,7 @@ export function initUpload(): void {
     errorSection.hidden = true;
     clearBtn.hidden = true;
     fileInput.value = '';
+    mapHandle.clear();
   }
 
   // Load from localStorage on init


### PR DESCRIPTION
## Summary

- Adds interactive Leaflet map that visualizes GPX routes as polylines with start/finish markers, auto-zoomed to fit the route bounds
- Introduces `route-map.ts` module with `LeafletFactory` dependency injection for testability (happy-dom can't render real Leaflet)
- Wires map into upload flow: routes display on file upload, localStorage restore, and clear on reset
- Adds responsive map container with placeholder empty state

## Test plan

- [x] `npm run test:run` — 29 tests pass (11 route-map, 4 upload integration, 14 existing gpx-parser)
- [x] `npm run build` — TypeScript strict mode compiles clean
- [ ] `npm run dev` — upload a GPX file, verify polyline + markers on map, auto-zoomed
- [ ] Clear route — map shows placeholder, no leftover layers
- [ ] Reload page — route restored from localStorage and displayed on map
- [ ] Test on narrow viewport (480px) — map fills width, 300px height

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)