### PR TITLE
fix: map tiles only partially load on iOS Safari

### DIFF
--- a/src/route-map.test.ts
+++ b/src/route-map.test.ts
@@ -23,6 +23,7 @@ function createMockFactory() {
     fitBounds: vi.fn(),
     setView: vi.fn(),
     remove: vi.fn(),
+    invalidateSize: vi.fn(),
   };
   const mockTileLayer = { addTo: vi.fn().mockReturnThis() };
 
@@ -188,6 +189,56 @@ describe('route-map', () => {
     expect(mocks.factory.polyline).not.toHaveBeenCalled();
     expect(mocks.factory.marker).toHaveBeenCalledOnce();
     expect(mocks.mockMap.setView).toHaveBeenCalledWith([50, 20], 14);
+  });
+
+  // Cycle 12: invalidateSize is called when route is shown
+  it('calls invalidateSize after showRoute', () => {
+    const route = makeRoute([
+      { lat: 50, lng: 20 },
+      { lat: 51, lng: 21 },
+    ]);
+
+    vi.stubGlobal(
+      'requestAnimationFrame',
+      vi.fn((cb: FrameRequestCallback) => {
+        cb(0);
+        return 0;
+      }),
+    );
+
+    handle.showRoute(route);
+
+    expect(mocks.mockMap.invalidateSize).toHaveBeenCalledOnce();
+
+    vi.unstubAllGlobals();
+  });
+
+  // Cycle 13: invalidateSize is deferred via requestAnimationFrame
+  it('defers invalidateSize via requestAnimationFrame', () => {
+    const route = makeRoute([
+      { lat: 50, lng: 20 },
+      { lat: 51, lng: 21 },
+    ]);
+
+    let rafCallback: FrameRequestCallback | null = null;
+    vi.stubGlobal(
+      'requestAnimationFrame',
+      vi.fn((cb: FrameRequestCallback) => {
+        rafCallback = cb;
+        return 0;
+      }),
+    );
+
+    handle.showRoute(route);
+
+    // Not called synchronously
+    expect(mocks.mockMap.invalidateSize).not.toHaveBeenCalled();
+
+    // Called after rAF fires
+    rafCallback!(0);
+    expect(mocks.mockMap.invalidateSize).toHaveBeenCalledOnce();
+
+    vi.unstubAllGlobals();
   });
 
   // Cycle 11: Placeholder when no route

--- a/src/route-map.ts
+++ b/src/route-map.ts
@@ -64,6 +64,10 @@ export function initRouteMap(
     placeholder.hidden = true;
     mapDiv.hidden = false;
 
+    requestAnimationFrame(() => {
+      map.invalidateSize();
+    });
+
     const latlngs: L.LatLngExpression[] = route.points.map(
       (p) => [p.lat, p.lng] as [number, number],
     );


### PR DESCRIPTION
## Summary

- Calls `map.invalidateSize()` after unhiding the map container in `showRoute()`, deferred via `requestAnimationFrame` so the browser completes layout first
- Fixes iOS Safari issue where Leaflet tiles only render in the top-left corner because the container size isn't detected after unhiding
- Adds 2 tests: one verifying `invalidateSize` is called, one verifying it's deferred via rAF

## Test plan

- [x] `npx vitest run src/route-map.test.ts` — all 13 tests pass
- [x] `npm run test:run` — full suite (31 tests) passes
- [x] `npm run build` — no TypeScript errors
- [ ] Manual: upload GPX on iOS Safari, verify tiles fully render

Closes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)