### PR TITLE
feat: add GPS position tracking and route matcher

### DIFF
--- a/src/geo.ts
+++ b/src/geo.ts
@@ -1,0 +1,15 @@
+export function haversine(
+  a: { lat: number; lng: number },
+  b: { lat: number; lng: number },
+): number {
+  const R = 6371000; // Earth radius in meters
+  const toRad = (deg: number) => (deg * Math.PI) / 180;
+  const dLat = toRad(b.lat - a.lat);
+  const dLng = toRad(b.lng - a.lng);
+  const sinLat = Math.sin(dLat / 2);
+  const sinLng = Math.sin(dLng / 2);
+  const h =
+    sinLat * sinLat +
+    Math.cos(toRad(a.lat)) * Math.cos(toRad(b.lat)) * sinLng * sinLng;
+  return 2 * R * Math.asin(Math.sqrt(h));
+}

--- a/src/gps-tracker.test.ts
+++ b/src/gps-tracker.test.ts
@@ -1,0 +1,154 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { initGpsTracker } from './gps-tracker';
+import type {
+  GeolocationProvider,
+  GpsTrackerHandle,
+  GpsState,
+} from './gps-tracker';
+import type { RoutePoint } from './gpx-parser';
+import { haversine } from './geo';
+
+function straightRoute(): RoutePoint[] {
+  const pts = [
+    { lat: 50, lng: 20 },
+    { lat: 50, lng: 20.01 },
+    { lat: 50, lng: 20.02 },
+    { lat: 50, lng: 20.03 },
+    { lat: 50, lng: 20.04 },
+  ];
+  let cumulative = 0;
+  return pts.map((p, i) => {
+    if (i > 0) cumulative += haversine(pts[i - 1], p);
+    return { ...p, cumulativeDistance: cumulative };
+  });
+}
+
+function createMockGeo() {
+  let successCb: PositionCallback | null = null;
+  let errorCb: PositionErrorCallback | null = null;
+  let nextId = 1;
+
+  const geo: GeolocationProvider = {
+    watchPosition: vi.fn((success, error, _options) => {
+      successCb = success;
+      errorCb = error ?? null;
+      return nextId++;
+    }),
+    clearWatch: vi.fn(),
+  };
+
+  function simulatePosition(lat: number, lng: number): void {
+    successCb!({
+      coords: {
+        latitude: lat,
+        longitude: lng,
+        accuracy: 10,
+        altitude: null,
+        altitudeAccuracy: null,
+        heading: null,
+        speed: null,
+      },
+      timestamp: Date.now(),
+    } as GeolocationPosition);
+  }
+
+  function simulateError(code: number): void {
+    errorCb!({ code, message: 'test error' } as GeolocationPositionError);
+  }
+
+  return { geo, simulatePosition, simulateError };
+}
+
+describe('gps-tracker', () => {
+  let mockGeo: ReturnType<typeof createMockGeo>;
+  let onChange: ReturnType<typeof vi.fn<(state: GpsState) => void>>;
+  let handle: GpsTrackerHandle;
+
+  beforeEach(() => {
+    mockGeo = createMockGeo();
+    onChange = vi.fn<(state: GpsState) => void>();
+    handle = initGpsTracker(mockGeo.geo, onChange);
+  });
+
+  // Slice 9: Module shape
+  it('returns handle with start, stop, getState', () => {
+    expect(typeof handle.start).toBe('function');
+    expect(typeof handle.stop).toBe('function');
+    expect(typeof handle.getState).toBe('function');
+  });
+
+  // Slice 10: start() calls watchPosition with enableHighAccuracy
+  it('calls watchPosition with enableHighAccuracy on start', () => {
+    handle.start(straightRoute());
+    expect(mockGeo.geo.watchPosition).toHaveBeenCalledOnce();
+    const options = vi.mocked(mockGeo.geo.watchPosition).mock.calls[0][2];
+    expect(options).toMatchObject({ enableHighAccuracy: true });
+  });
+
+  // Slice 11: Position update triggers onChange
+  it('triggers onChange with position and match result', () => {
+    handle.start(straightRoute());
+    mockGeo.simulatePosition(50, 20.01);
+
+    expect(onChange).toHaveBeenCalledOnce();
+    const state: GpsState = onChange.mock.calls[0][0];
+    expect(state.position).toEqual({ lat: 50, lng: 20.01 });
+    expect(state.match).not.toBeNull();
+    expect(state.match!.isOnRoute).toBe(true);
+    expect(state.error).toBeNull();
+  });
+
+  // Slice 12: Forward progression maintained
+  it('maintains forward progression across updates', () => {
+    handle.start(straightRoute());
+
+    mockGeo.simulatePosition(50, 20.02);
+    const first = onChange.mock.calls[0][0] as GpsState;
+
+    mockGeo.simulatePosition(50, 20.03);
+    const second = onChange.mock.calls[1][0] as GpsState;
+
+    expect(second.match!.nearestPointIndex).toBeGreaterThanOrEqual(
+      first.match!.nearestPointIndex,
+    );
+  });
+
+  // Slice 13: Error — permission denied
+  it('sets error to denied on code 1', () => {
+    handle.start(straightRoute());
+    mockGeo.simulateError(1);
+
+    expect(onChange).toHaveBeenCalledOnce();
+    const state: GpsState = onChange.mock.calls[0][0];
+    expect(state.error).toBe('denied');
+  });
+
+  // Slice 14: Error — unavailable
+  it('sets error to unavailable on code 2', () => {
+    handle.start(straightRoute());
+    mockGeo.simulateError(2);
+
+    const state: GpsState = onChange.mock.calls[0][0];
+    expect(state.error).toBe('unavailable');
+  });
+
+  // Slice 15: stop() clears the watch
+  it('calls clearWatch on stop', () => {
+    handle.start(straightRoute());
+    handle.stop();
+    expect(mockGeo.geo.clearWatch).toHaveBeenCalledOnce();
+  });
+
+  // Slice 16: start() after stop() resets state
+  it('resets state when start called after stop', () => {
+    handle.start(straightRoute());
+    mockGeo.simulatePosition(50, 20.03);
+    handle.stop();
+
+    handle.start(straightRoute());
+    const state = handle.getState();
+    expect(state.position).toBeNull();
+    expect(state.match).toBeNull();
+    expect(state.error).toBeNull();
+  });
+});

--- a/src/gps-tracker.ts
+++ b/src/gps-tracker.ts
@@ -1,0 +1,84 @@
+import type { RoutePoint } from './gpx-parser';
+import { matchPosition } from './route-matcher';
+import type { MatchResult } from './route-matcher';
+
+export interface GeolocationProvider {
+  watchPosition(
+    success: PositionCallback,
+    error?: PositionErrorCallback | null,
+    options?: PositionOptions,
+  ): number;
+  clearWatch(watchId: number): void;
+}
+
+export interface GpsState {
+  position: { lat: number; lng: number } | null;
+  match: MatchResult | null;
+  error: 'denied' | 'unavailable' | 'timeout' | null;
+}
+
+export interface GpsTrackerHandle {
+  start(route: RoutePoint[]): void;
+  stop(): void;
+  getState(): GpsState;
+}
+
+export function initGpsTracker(
+  geo: GeolocationProvider,
+  onChange: (state: GpsState) => void,
+): GpsTrackerHandle {
+  let state: GpsState = { position: null, match: null, error: null };
+  let watchId: number | null = null;
+  let route: RoutePoint[] = [];
+  let lastKnownIndex: number | undefined;
+
+  function handlePosition(pos: GeolocationPosition): void {
+    const position = { lat: pos.coords.latitude, lng: pos.coords.longitude };
+    const match = matchPosition(route, position, lastKnownIndex);
+
+    if (
+      lastKnownIndex === undefined ||
+      match.nearestPointIndex >= lastKnownIndex
+    ) {
+      lastKnownIndex = match.nearestPointIndex;
+    }
+
+    state = { position, match, error: null };
+    onChange(state);
+  }
+
+  function handleError(err: GeolocationPositionError): void {
+    const errorMap: Record<number, 'denied' | 'unavailable' | 'timeout'> = {
+      1: 'denied',
+      2: 'unavailable',
+      3: 'timeout',
+    };
+    state = { ...state, error: errorMap[err.code] ?? 'unavailable' };
+    onChange(state);
+  }
+
+  function start(newRoute: RoutePoint[]): void {
+    if (watchId !== null) {
+      geo.clearWatch(watchId);
+    }
+    route = newRoute;
+    lastKnownIndex = undefined;
+    state = { position: null, match: null, error: null };
+    watchId = geo.watchPosition(handlePosition, handleError, {
+      enableHighAccuracy: true,
+    });
+  }
+
+  function stop(): void {
+    if (watchId !== null) {
+      geo.clearWatch(watchId);
+      watchId = null;
+    }
+  }
+
+  function getState(): GpsState {
+    return state;
+  }
+
+  return { start, stop, getState };
+}

--- a/src/gpx-parser.ts
+++ b/src/gpx-parser.ts
@@ -1,3 +1,5 @@
+import { haversine } from './geo';
+
 export interface RoutePoint {
   lat: number;
   lng: number;
@@ -105,18 +107,3 @@ function computeDistances(
   });
 }
 
-function haversine(
-  a: { lat: number; lng: number },
-  b: { lat: number; lng: number },
-): number {
-  const R = 6371000; // Earth radius in meters
-  const toRad = (deg: number) => (deg * Math.PI) / 180;
-  const dLat = toRad(b.lat - a.lat);
-  const dLng = toRad(b.lng - a.lng);
-  const sinLat = Math.sin(dLat / 2);
-  const sinLng = Math.sin(dLng / 2);
-  const h =
-    sinLat * sinLat +
-    Math.cos(toRad(a.lat)) * Math.cos(toRad(b.lat)) * sinLng * sinLng;
-  return 2 * R * Math.asin(Math.sqrt(h));
-}

--- a/src/main.ts
+++ b/src/main.ts
@@ -19,6 +19,7 @@ setDefaultFactory({
   tileLayer: (url, options) => L.tileLayer(url, options),
   polyline: (latlngs, options) => L.polyline(latlngs, options),
   marker: (latlng, options) => L.marker(latlng, options),
+  circleMarker: (latlng, options) => L.circleMarker(latlng, options),
 });
 
 initUpload();

--- a/src/route-map.test.ts
+++ b/src/route-map.test.ts
@@ -29,6 +29,7 @@ function createMockFactory() {
 
   const polylines: Array<{ addTo: ReturnType<typeof vi.fn>; remove: ReturnType<typeof vi.fn>; getBounds: ReturnType<typeof vi.fn> }> = [];
   const markers: Array<{ addTo: ReturnType<typeof vi.fn>; remove: ReturnType<typeof vi.fn> }> = [];
+  const circleMarkers: Array<{ addTo: ReturnType<typeof vi.fn>; remove: ReturnType<typeof vi.fn>; setLatLng: ReturnType<typeof vi.fn> }> = [];
 
   const factory: LeafletFactory = {
     map: vi.fn(() => mockMap) as unknown as LeafletFactory['map'],
@@ -49,9 +50,18 @@ function createMockFactory() {
       markers.push(m);
       return m;
     }) as unknown as LeafletFactory['marker'],
+    circleMarker: vi.fn(() => {
+      const cm = {
+        addTo: vi.fn().mockReturnThis(),
+        remove: vi.fn(),
+        setLatLng: vi.fn().mockReturnThis(),
+      };
+      circleMarkers.push(cm);
+      return cm;
+    }) as unknown as LeafletFactory['circleMarker'],
   };
 
-  return { factory, mockMap, mockTileLayer, polylines, markers };
+  return { factory, mockMap, mockTileLayer, polylines, markers, circleMarkers };
 }
 
 describe('route-map', () => {
@@ -257,5 +267,50 @@ describe('route-map', () => {
 
     handle.clear();
     expect(placeholder.hidden).toBe(false);
+  });
+
+  // Cycle 17: showRiderPosition creates circleMarker on map
+  it('showRiderPosition creates circleMarker on map', () => {
+    handle.showRiderPosition({ lat: 50.5, lng: 20.5 });
+
+    expect(mocks.factory.circleMarker).toHaveBeenCalledOnce();
+    const call = vi.mocked(mocks.factory.circleMarker).mock.calls[0];
+    expect(call[0]).toEqual([50.5, 20.5]);
+    expect(mocks.circleMarkers[0].addTo).toHaveBeenCalledWith(mocks.mockMap);
+  });
+
+  // Cycle 18: Subsequent showRiderPosition calls setLatLng
+  it('subsequent showRiderPosition calls setLatLng instead of creating new marker', () => {
+    handle.showRiderPosition({ lat: 50.5, lng: 20.5 });
+    handle.showRiderPosition({ lat: 50.6, lng: 20.6 });
+
+    expect(mocks.factory.circleMarker).toHaveBeenCalledOnce();
+    expect(mocks.circleMarkers[0].setLatLng).toHaveBeenCalledWith([50.6, 20.6]);
+  });
+
+  // Cycle 19: clearRiderPosition removes marker
+  it('clearRiderPosition removes the rider marker', () => {
+    handle.showRiderPosition({ lat: 50.5, lng: 20.5 });
+    handle.clearRiderPosition();
+
+    expect(mocks.circleMarkers[0].remove).toHaveBeenCalledOnce();
+  });
+
+  // Cycle 20: showOffRouteWarning shows banner
+  it('showOffRouteWarning shows the off-route banner', () => {
+    const banner = container.querySelector('.off-route-warning') as HTMLElement;
+    expect(banner.hidden).toBe(true);
+
+    handle.showOffRouteWarning();
+    expect(banner.hidden).toBe(false);
+  });
+
+  // Cycle 21: hideOffRouteWarning hides banner
+  it('hideOffRouteWarning hides the off-route banner', () => {
+    handle.showOffRouteWarning();
+    handle.hideOffRouteWarning();
+
+    const banner = container.querySelector('.off-route-warning') as HTMLElement;
+    expect(banner.hidden).toBe(true);
   });
 });

--- a/src/route-map.ts
+++ b/src/route-map.ts
@@ -5,6 +5,10 @@ export interface RouteMapHandle {
   showRoute(route: ParsedRoute): void;
   clear(): void;
   destroy(): void;
+  showRiderPosition(position: { lat: number; lng: number }): void;
+  clearRiderPosition(): void;
+  showOffRouteWarning(): void;
+  hideOffRouteWarning(): void;
 }
 
 export interface LeafletFactory {
@@ -15,6 +19,10 @@ export interface LeafletFactory {
     options?: L.PolylineOptions,
   ): L.Polyline;
   marker(latlng: L.LatLngExpression, options?: L.MarkerOptions): L.Marker;
+  circleMarker(
+    latlng: L.LatLngExpression,
+    options?: L.CircleMarkerOptions,
+  ): L.CircleMarker;
 }
 
 const DEFAULT_CENTER: L.LatLngExpression = [0, 0];
@@ -47,6 +55,13 @@ export function initRouteMap(
 
   let currentPolyline: L.Polyline | null = null;
   let currentMarkers: L.Marker[] = [];
+  let riderMarker: L.CircleMarker | null = null;
+
+  const offRouteBanner = document.createElement('div');
+  offRouteBanner.className = 'off-route-warning';
+  offRouteBanner.textContent = 'You are off route';
+  offRouteBanner.hidden = true;
+  container.appendChild(offRouteBanner);
 
   function removeLayers(): void {
     if (currentPolyline) {
@@ -112,10 +127,50 @@ export function initRouteMap(
     map.remove();
   }
 
+  function showRiderPosition(position: { lat: number; lng: number }): void {
+    const latlng: L.LatLngExpression = [position.lat, position.lng];
+    if (riderMarker) {
+      riderMarker.setLatLng(latlng);
+    } else {
+      riderMarker = leaflet
+        .circleMarker(latlng, {
+          radius: 8,
+          color: '#2563eb',
+          fillColor: '#3b82f6',
+          fillOpacity: 1,
+          weight: 2,
+        })
+        .addTo(map);
+    }
+  }
+
+  function clearRiderPosition(): void {
+    if (riderMarker) {
+      riderMarker.remove();
+      riderMarker = null;
+    }
+  }
+
+  function showOffRouteWarning(): void {
+    offRouteBanner.hidden = false;
+  }
+
+  function hideOffRouteWarning(): void {
+    offRouteBanner.hidden = true;
+  }
+
   // Initial state: placeholder visible, map hidden
   mapDiv.hidden = true;
 
-  return { showRoute, clear, destroy };
+  return {
+    showRoute,
+    clear,
+    destroy,
+    showRiderPosition,
+    clearRiderPosition,
+    showOffRouteWarning,
+    hideOffRouteWarning,
+  };
 }
 
 let defaultFactory: LeafletFactory | undefined;

--- a/src/route-matcher.test.ts
+++ b/src/route-matcher.test.ts
@@ -1,0 +1,166 @@
+import { describe, it, expect } from 'vitest';
+import { matchPosition } from './route-matcher';
+import type { MatchResult } from './route-matcher';
+import type { RoutePoint } from './gpx-parser';
+import { haversine } from './geo';
+
+// Helper: build a straight route along a line of latitude
+function straightRoute(
+  startLat: number,
+  startLng: number,
+  points: number,
+  spacingDeg: number,
+): RoutePoint[] {
+  const route: RoutePoint[] = [];
+  let cumulative = 0;
+  for (let i = 0; i < points; i++) {
+    const p = { lat: startLat, lng: startLng + i * spacingDeg };
+    if (i > 0) {
+      cumulative += haversine(route[i - 1], p);
+    }
+    route.push({ ...p, cumulativeDistance: cumulative });
+  }
+  return route;
+}
+
+describe('route-matcher', () => {
+  // Slice 1: Module shape
+  it('returns object with all MatchResult fields', () => {
+    const route = straightRoute(50, 20, 3, 0.01);
+    const result: MatchResult = matchPosition(route, { lat: 50, lng: 20.01 });
+    expect(result).toHaveProperty('isOnRoute');
+    expect(result).toHaveProperty('nearestPointIndex');
+    expect(result).toHaveProperty('distanceFromRoute');
+    expect(result).toHaveProperty('cumulativeDistance');
+  });
+
+  // Slice 2: Nearest point on straight route
+  it('returns index 1, distance ~0 when position is exactly on point 1', () => {
+    const route = straightRoute(50, 20, 3, 0.01);
+    const result = matchPosition(route, { lat: 50, lng: 20.01 });
+    expect(result.nearestPointIndex).toBe(1);
+    expect(result.distanceFromRoute).toBeLessThan(1); // < 1m
+    expect(result.isOnRoute).toBe(true);
+  });
+
+  // Slice 3: Off-route detection
+  it('marks position 1km from route as off-route', () => {
+    const route = straightRoute(50, 20, 3, 0.01);
+    // ~0.009 degrees latitude ≈ 1km
+    const result = matchPosition(route, { lat: 50.009, lng: 20.01 });
+    expect(result.isOnRoute).toBe(false);
+    expect(result.distanceFromRoute).toBeGreaterThan(900);
+    expect(result.distanceFromRoute).toBeLessThan(1100);
+  });
+
+  // Slice 4: Between-point interpolation
+  it('computes correct cumulativeDistance for midpoint of segment', () => {
+    const route = straightRoute(50, 20, 3, 0.01);
+    // Halfway between point 0 and point 1
+    const result = matchPosition(route, { lat: 50, lng: 20.005 });
+    const expectedCumDist =
+      (route[0].cumulativeDistance + route[1].cumulativeDistance) / 2;
+    expect(result.cumulativeDistance).toBeCloseTo(expectedCumDist, 0);
+    expect(result.isOnRoute).toBe(true);
+  });
+
+  // Slice 5: Boundary — 499m vs 501m
+  it('499m from route is on-route', () => {
+    const route = straightRoute(50, 20, 3, 0.01);
+    // 499m north of the route ≈ 0.00449 degrees latitude
+    const offsetLat = 499 / 111_320;
+    const result = matchPosition(route, {
+      lat: 50 + offsetLat,
+      lng: 20.01,
+    });
+    expect(result.isOnRoute).toBe(true);
+  });
+
+  it('501m from route is off-route', () => {
+    const route = straightRoute(50, 20, 3, 0.01);
+    const offsetLat = 501 / 111_320;
+    const result = matchPosition(route, {
+      lat: 50 + offsetLat,
+      lng: 20.01,
+    });
+    expect(result.isOnRoute).toBe(false);
+  });
+
+  // Slice 6: Forward progression with lastKnownIndex hint
+  it('resolves to forward point when lastKnownIndex is provided', () => {
+    // Create a route that goes east then comes back west (loop-like)
+    const route: RoutePoint[] = [];
+    let cumulative = 0;
+    const pts = [
+      { lat: 50, lng: 20 },
+      { lat: 50, lng: 20.01 },
+      { lat: 50.005, lng: 20.02 },
+      { lat: 50.01, lng: 20.01 }, // passes near lng 20.01 again
+      { lat: 50.01, lng: 20 },
+    ];
+    for (let i = 0; i < pts.length; i++) {
+      if (i > 0) cumulative += haversine(pts[i - 1], pts[i]);
+      route.push({ ...pts[i], cumulativeDistance: cumulative });
+    }
+
+    // Position near lng 20.01 — without hint, could match segment 0-1 or 2-3
+    // With lastKnownIndex=2, should prefer the forward segment 2-3
+    const result = matchPosition(
+      route,
+      { lat: 50.008, lng: 20.012 },
+      2,
+    );
+    expect(result.nearestPointIndex).toBeGreaterThanOrEqual(2);
+  });
+
+  // Slice 7: Out-and-back — lastKnownIndex near turnaround
+  it('handles out-and-back route with lastKnownIndex near turnaround', () => {
+    const route: RoutePoint[] = [];
+    let cumulative = 0;
+    // Out: 0->1->2, Back: 2->3->4 (3 and 4 retrace path)
+    const pts = [
+      { lat: 50, lng: 20 },
+      { lat: 50, lng: 20.01 },
+      { lat: 50, lng: 20.02 }, // turnaround
+      { lat: 50, lng: 20.01 }, // same as point 1
+      { lat: 50, lng: 20 }, // same as point 0
+    ];
+    for (let i = 0; i < pts.length; i++) {
+      if (i > 0) cumulative += haversine(pts[i - 1], pts[i]);
+      route.push({ ...pts[i], cumulativeDistance: cumulative });
+    }
+
+    // Near turnaround, hint index 2
+    const result = matchPosition(route, { lat: 50, lng: 20.019 }, 2);
+    expect(result.nearestPointIndex).toBeGreaterThanOrEqual(2);
+    expect(result.isOnRoute).toBe(true);
+  });
+
+  // Slice 8: Edge cases
+  it('handles single-point route', () => {
+    const route: RoutePoint[] = [
+      { lat: 50, lng: 20, cumulativeDistance: 0 },
+    ];
+    const result = matchPosition(route, { lat: 50, lng: 20 });
+    expect(result.nearestPointIndex).toBe(0);
+    expect(result.distanceFromRoute).toBeLessThan(1);
+    expect(result.isOnRoute).toBe(true);
+  });
+
+  it('handles position on first point', () => {
+    const route = straightRoute(50, 20, 5, 0.01);
+    const result = matchPosition(route, { lat: 50, lng: 20 });
+    expect(result.nearestPointIndex).toBe(0);
+    expect(result.distanceFromRoute).toBeLessThan(1);
+    expect(result.cumulativeDistance).toBeCloseTo(0, 0);
+  });
+
+  it('handles position on last point', () => {
+    const route = straightRoute(50, 20, 5, 0.01);
+    const lastPt = route[route.length - 1];
+    const result = matchPosition(route, { lat: lastPt.lat, lng: lastPt.lng });
+    expect(result.nearestPointIndex).toBe(4);
+    expect(result.distanceFromRoute).toBeLessThan(1);
+    expect(result.cumulativeDistance).toBeCloseTo(lastPt.cumulativeDistance, 0);
+  });
+});

--- a/src/route-matcher.ts
+++ b/src/route-matcher.ts
@@ -1,0 +1,110 @@
+import type { RoutePoint } from './gpx-parser';
+import { haversine } from './geo';
+
+const OFF_ROUTE_THRESHOLD = 500; // meters
+
+export interface MatchResult {
+  isOnRoute: boolean;
+  nearestPointIndex: number;
+  distanceFromRoute: number;
+  cumulativeDistance: number;
+}
+
+export function matchPosition(
+  route: RoutePoint[],
+  position: { lat: number; lng: number },
+  lastKnownIndex?: number,
+): MatchResult {
+  if (route.length === 0) {
+    return {
+      isOnRoute: false,
+      nearestPointIndex: 0,
+      distanceFromRoute: Infinity,
+      cumulativeDistance: 0,
+    };
+  }
+
+  if (route.length === 1) {
+    const dist = haversine(route[0], position);
+    return {
+      isOnRoute: dist <= OFF_ROUTE_THRESHOLD,
+      nearestPointIndex: 0,
+      distanceFromRoute: dist,
+      cumulativeDistance: route[0].cumulativeDistance,
+    };
+  }
+
+  // If lastKnownIndex provided, try windowed search first
+  if (lastKnownIndex !== undefined) {
+    const windowResult = searchSegments(
+      route,
+      position,
+      Math.max(0, lastKnownIndex - 5),
+      Math.min(route.length - 1, lastKnownIndex + 50),
+    );
+    if (windowResult.distanceFromRoute <= OFF_ROUTE_THRESHOLD) {
+      return { ...windowResult, isOnRoute: true };
+    }
+  }
+
+  // Full scan
+  const result = searchSegments(route, position, 0, route.length - 1);
+  return {
+    ...result,
+    isOnRoute: result.distanceFromRoute <= OFF_ROUTE_THRESHOLD,
+  };
+}
+
+function searchSegments(
+  route: RoutePoint[],
+  position: { lat: number; lng: number },
+  startIdx: number,
+  endIdx: number,
+): Omit<MatchResult, 'isOnRoute'> {
+  let bestDist = Infinity;
+  let bestIndex = startIdx;
+  let bestCumulativeDist = route[startIdx].cumulativeDistance;
+
+  for (let i = startIdx; i < endIdx; i++) {
+    const a = route[i];
+    const b = route[i + 1];
+
+    // Project position onto segment using cosine-corrected Cartesian approximation
+    const cosLat = Math.cos(((a.lat + b.lat) / 2) * (Math.PI / 180));
+    const ax = a.lng * cosLat;
+    const ay = a.lat;
+    const bx = b.lng * cosLat;
+    const by = b.lat;
+    const px = position.lng * cosLat;
+    const py = position.lat;
+
+    const dx = bx - ax;
+    const dy = by - ay;
+    const lenSq = dx * dx + dy * dy;
+
+    let t = 0;
+    if (lenSq > 0) {
+      t = Math.max(0, Math.min(1, ((px - ax) * dx + (py - ay) * dy) / lenSq));
+    }
+
+    // Projected point in real coordinates
+    const projLat = a.lat + t * (b.lat - a.lat);
+    const projLng = a.lng + t * (b.lng - a.lng);
+
+    const dist = haversine(position, { lat: projLat, lng: projLng });
+
+    if (dist < bestDist) {
+      bestDist = dist;
+      bestIndex = t <= 0.5 ? i : i + 1;
+      bestCumulativeDist =
+        a.cumulativeDistance +
+        t * (b.cumulativeDistance - a.cumulativeDistance);
+    }
+  }
+
+  return {
+    nearestPointIndex: bestIndex,
+    distanceFromRoute: bestDist,
+    cumulativeDistance: bestCumulativeDist,
+  };
+}

--- a/src/style.css
+++ b/src/style.css
@@ -115,3 +115,15 @@ h1 {
   background: #f3f4f6;
   border-radius: 0.5rem;
 }
+
+.off-route-warning {
+  padding: 0.75rem 1rem;
+  background: #fef2f2;
+  color: #dc2626;
+  border: 1px solid #fecaca;
+  border-radius: 0.5rem;
+  font-size: 0.9rem;
+  font-weight: 500;
+  text-align: center;
+  margin-top: 0.5rem;
+}

--- a/src/upload.test.ts
+++ b/src/upload.test.ts
@@ -46,8 +46,20 @@ vi.mock('./route-map', () => {
   const showRoute = vi.fn();
   const clear = vi.fn();
   const destroy = vi.fn();
+  const showRiderPosition = vi.fn();
+  const clearRiderPosition = vi.fn();
+  const showOffRouteWarning = vi.fn();
+  const hideOffRouteWarning = vi.fn();
   return {
-    initRouteMap: vi.fn(() => ({ showRoute, clear, destroy })),
+    initRouteMap: vi.fn(() => ({
+      showRoute,
+      clear,
+      destroy,
+      showRiderPosition,
+      clearRiderPosition,
+      showOffRouteWarning,
+      hideOffRouteWarning,
+    })),
     setDefaultFactory: vi.fn(),
   };
 });
@@ -105,6 +117,150 @@ describe('upload integration with map', () => {
     const { initRouteMap } = await import('./route-map');
     initUpload();
     const handle = vi.mocked(initRouteMap).mock.results[0].value;
+
+    expect(handle.showRoute).toHaveBeenCalledOnce();
+  });
+});
+
+function createMockGeo() {
+  let successCb: PositionCallback | null = null;
+  let errorCb: PositionErrorCallback | null = null;
+  let nextId = 1;
+
+  const geo = {
+    watchPosition: vi.fn((success: PositionCallback, error?: PositionErrorCallback | null) => {
+      successCb = success;
+      errorCb = error ?? null;
+      return nextId++;
+    }),
+    clearWatch: vi.fn(),
+  };
+
+  function simulatePosition(lat: number, lng: number): void {
+    successCb!({
+      coords: {
+        latitude: lat,
+        longitude: lng,
+        accuracy: 10,
+        altitude: null,
+        altitudeAccuracy: null,
+        heading: null,
+        speed: null,
+      },
+      timestamp: Date.now(),
+    } as GeolocationPosition);
+  }
+
+  function simulateError(code: number): void {
+    errorCb!({ code, message: 'test' } as GeolocationPositionError);
+  }
+
+  return { geo, simulatePosition, simulateError };
+}
+
+describe('upload GPS integration', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    setupDOM();
+    vi.clearAllMocks();
+  });
+
+  // Slice 23: When route is displayed, GPS tracker starts
+  it('starts GPS tracker when route is shown', async () => {
+    const mockGeo = createMockGeo();
+    initUpload(mockGeo.geo);
+
+    simulateFileUpload(MINIMAL_2_TRKPT);
+    await flushFileReader();
+
+    expect(mockGeo.geo.watchPosition).toHaveBeenCalledOnce();
+  });
+
+  // Slice 24: GPS onChange with position -> showRiderPosition
+  it('shows rider position on GPS update', async () => {
+    const { initRouteMap } = await import('./route-map');
+    const mockGeo = createMockGeo();
+    initUpload(mockGeo.geo);
+    const handle = vi.mocked(initRouteMap).mock.results[0].value;
+
+    simulateFileUpload(MINIMAL_2_TRKPT);
+    await flushFileReader();
+
+    mockGeo.simulatePosition(50, 20);
+
+    expect(handle.showRiderPosition).toHaveBeenCalledWith({ lat: 50, lng: 20 });
+  });
+
+  // Slice 25: onChange with isOnRoute: false -> showOffRouteWarning
+  it('shows off-route warning when position is far from route', async () => {
+    const { initRouteMap } = await import('./route-map');
+    const mockGeo = createMockGeo();
+    initUpload(mockGeo.geo);
+    const handle = vi.mocked(initRouteMap).mock.results[0].value;
+
+    simulateFileUpload(MINIMAL_2_TRKPT);
+    await flushFileReader();
+
+    // Position far from route
+    mockGeo.simulatePosition(60, 30);
+
+    expect(handle.showOffRouteWarning).toHaveBeenCalled();
+  });
+
+  // Slice 26: onChange with isOnRoute: true after off-route -> hideOffRouteWarning
+  it('hides off-route warning when back on route', async () => {
+    const { initRouteMap } = await import('./route-map');
+    const mockGeo = createMockGeo();
+    initUpload(mockGeo.geo);
+    const handle = vi.mocked(initRouteMap).mock.results[0].value;
+
+    simulateFileUpload(MINIMAL_2_TRKPT);
+    await flushFileReader();
+
+    // First: off-route
+    mockGeo.simulatePosition(60, 30);
+    // Then: on-route (the fixture has points at lat 50, lng 20)
+    mockGeo.simulatePosition(50, 20);
+
+    expect(handle.hideOffRouteWarning).toHaveBeenCalled();
+  });
+
+  // Slice 27: GPS error: denied -> no crash, no marker
+  it('handles GPS permission denied without crashing', async () => {
+    const { initRouteMap } = await import('./route-map');
+    const mockGeo = createMockGeo();
+    initUpload(mockGeo.geo);
+    const handle = vi.mocked(initRouteMap).mock.results[0].value;
+
+    simulateFileUpload(MINIMAL_2_TRKPT);
+    await flushFileReader();
+
+    expect(() => mockGeo.simulateError(1)).not.toThrow();
+    expect(handle.showRiderPosition).not.toHaveBeenCalled();
+  });
+
+  // Slice 28: Clear route -> gpsTracker.stop()
+  it('stops GPS tracker when route is cleared', async () => {
+    const mockGeo = createMockGeo();
+    initUpload(mockGeo.geo);
+
+    simulateFileUpload(MINIMAL_2_TRKPT);
+    await flushFileReader();
+
+    const clearBtn = document.getElementById('clear-btn') as HTMLButtonElement;
+    clearBtn.click();
+
+    expect(mockGeo.geo.clearWatch).toHaveBeenCalled();
+  });
+
+  // Slice 29: No geolocation -> app works normally
+  it('works without geolocation provider', async () => {
+    const { initRouteMap } = await import('./route-map');
+    initUpload(); // no geo provider
+    const handle = vi.mocked(initRouteMap).mock.results[0].value;
+
+    simulateFileUpload(MINIMAL_2_TRKPT);
+    await flushFileReader();
 
     expect(handle.showRoute).toHaveBeenCalledOnce();
   });

--- a/src/upload.ts
+++ b/src/upload.ts
@@ -1,10 +1,12 @@
 import { parseGPX } from './gpx-parser';
 import type { ParsedRoute } from './gpx-parser';
 import { initRouteMap } from './route-map';
+import { initGpsTracker } from './gps-tracker';
+import type { GeolocationProvider, GpsTrackerHandle } from './gps-tracker';
 
 const STORAGE_KEY = 'fuelspot-gpx';
 
-export function initUpload(): void {
+export function initUpload(geo?: GeolocationProvider): void {
   const fileInput = document.getElementById('gpx-input') as HTMLInputElement;
   const clearBtn = document.getElementById('clear-btn') as HTMLButtonElement;
   const statsSection = document.getElementById('route-stats') as HTMLElement;
@@ -16,6 +18,27 @@ export function initUpload(): void {
 
   const mapHandle = initRouteMap(mapContainer);
 
+  let gpsTracker: GpsTrackerHandle | null = null;
+
+  const geoProvider = geo ?? (typeof navigator !== 'undefined' && navigator.geolocation
+    ? navigator.geolocation
+    : null);
+
+  if (geoProvider) {
+    gpsTracker = initGpsTracker(geoProvider, (state) => {
+      if (state.position) {
+        mapHandle.showRiderPosition(state.position);
+      }
+      if (state.match) {
+        if (state.match.isOnRoute) {
+          mapHandle.hideOffRouteWarning();
+        } else {
+          mapHandle.showOffRouteWarning();
+        }
+      }
+    });
+  }
+
   function showRoute(route: ParsedRoute): void {
     routeName.textContent = route.name ?? 'Unnamed route';
     pointCount.textContent = `${route.points.length} points`;
@@ -24,6 +47,7 @@ export function initUpload(): void {
     errorSection.hidden = true;
     clearBtn.hidden = false;
     mapHandle.showRoute(route);
+    gpsTracker?.start(route.points);
   }
 
   function showError(message: string): void {
@@ -38,6 +62,9 @@ export function initUpload(): void {
     clearBtn.hidden = true;
     fileInput.value = '';
     mapHandle.clear();
+    gpsTracker?.stop();
+    mapHandle.clearRiderPosition();
+    mapHandle.hideOffRouteWarning();
   }
 
   // Load from localStorage on init


### PR DESCRIPTION
## Summary
- Extract `haversine` to shared `src/geo.ts` module for reuse across route matcher and GPX parser
- Add pure `matchPosition()` function that projects rider position onto GPX route segments with cosine-corrected Cartesian approximation, windowed search optimization via `lastKnownIndex`, and 500m on/off-route threshold
- Add `initGpsTracker()` stateful wrapper around Geolocation API with DI for testability, forward-progression tracking, and error mapping (denied/unavailable/timeout)
- Extend `RouteMapHandle` with `showRiderPosition`, `clearRiderPosition`, `showOffRouteWarning`, `hideOffRouteWarning` using Leaflet `circleMarker`
- Wire GPS tracking into upload flow — starts on route display, stops on clear, gracefully handles missing geolocation

## Test Plan
- [x] 62 tests pass (`npm run test:run`)
- [x] TypeScript strict build passes (`npm run build`)
- [ ] Manual: upload GPX, use browser geolocation override to simulate on-route position — verify blue circle marker
- [ ] Manual: simulate position >500m from route — verify red "You are off route" banner
- [ ] Manual: deny GPS permission — verify app works normally without marker
- [ ] Manual: clear route — verify marker and banner removed

Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)