### PR TITLE
feat: POI fetcher with Overpass API and map pins

### DIFF
--- a/index.html
+++ b/index.html
@@ -24,6 +24,8 @@
       <p id="error-display" hidden></p>
 
       <button id="clear-btn" type="button" hidden>Clear route</button>
+      <button id="refresh-btn" type="button" hidden>Refresh stops</button>
+      <p id="loading-indicator" hidden>Loading stops…</p>
 
       <div id="map-container"></div>
     </div>

--- a/src/poi-fetcher.test.ts
+++ b/src/poi-fetcher.test.ts
@@ -1,0 +1,227 @@
+import { describe, it, expect, vi } from 'vitest';
+import type { RoutePoint } from './gpx-parser';
+import {
+  buildOverpassQuery,
+  parseOverpassResponse,
+  fetchPOIs,
+} from './poi-fetcher';
+import type { OverpassClient, OverpassResponse } from './poi-fetcher';
+
+function makePoints(count: number): RoutePoint[] {
+  return Array.from({ length: count }, (_, i) => ({
+    lat: 50 + i * 0.01,
+    lng: 20 + i * 0.01,
+    cumulativeDistance: i * 100,
+  }));
+}
+
+describe('buildOverpassQuery', () => {
+  // Slice 1: produces valid Overpass QL with all 6 POI categories
+  it('contains all 6 POI categories and coordinate pairs', () => {
+    const points = makePoints(3);
+    const query = buildOverpassQuery(points);
+
+    expect(query).toContain('"amenity"="fuel"');
+    expect(query).toContain('"shop"="convenience"');
+    expect(query).toContain('"shop"="supermarket"');
+    expect(query).toContain('"shop"="bakery"');
+    expect(query).toContain('"amenity"="restaurant"');
+    expect(query).toContain('"amenity"="cafe"');
+
+    for (const p of points) {
+      expect(query).toContain(`${p.lat}`);
+      expect(query).toContain(`${p.lng}`);
+    }
+
+    expect(query).toContain('around:300');
+    expect(query).toContain('out center body');
+    expect(query).toContain('[out:json]');
+    expect(query).toContain('[timeout:30]');
+  });
+
+  // Slice 2: samples points when route has many points
+  it('samples points for large routes', () => {
+    const points = makePoints(500);
+    const query = buildOverpassQuery(points);
+
+    // Should have fewer coordinate pairs than 500
+    const coordMatches = query.match(/\d+\.\d+,\d+\.\d+/g) ?? [];
+    // Each nwr line has the same coords, so divide by 6 categories
+    const uniqueCoordCount = coordMatches.length / 6;
+    expect(uniqueCoordCount).toBeLessThan(500);
+    expect(uniqueCoordCount).toBeGreaterThan(0);
+
+    // Should always include first and last points
+    expect(query).toContain(`${points[0].lat}`);
+    expect(query).toContain(`${points[499].lat}`);
+  });
+});
+
+describe('parseOverpassResponse', () => {
+  // Slice 3: extracts POIs with all fields
+  it('extracts POIs from complete response', () => {
+    const response: OverpassResponse = {
+      elements: [
+        {
+          id: 123,
+          type: 'node',
+          lat: 50.1,
+          lon: 20.1,
+          tags: {
+            name: 'Shell Station',
+            amenity: 'fuel',
+            opening_hours: 'Mo-Su 06:00-22:00',
+            'payment:credit_cards': 'yes',
+          },
+        },
+      ],
+    };
+
+    const pois = parseOverpassResponse(response);
+    expect(pois).toHaveLength(1);
+    expect(pois[0]).toEqual({
+      id: 123,
+      name: 'Shell Station',
+      type: 'fuel',
+      lat: 50.1,
+      lng: 20.1,
+      openingHours: 'Mo-Su 06:00-22:00',
+      acceptsCards: true,
+    });
+  });
+
+  // Slice 4: handles missing optional fields
+  it('defaults to null for missing optional fields', () => {
+    const response: OverpassResponse = {
+      elements: [
+        {
+          id: 456,
+          type: 'node',
+          lat: 50.2,
+          lon: 20.2,
+          tags: { amenity: 'cafe' },
+        },
+      ],
+    };
+
+    const pois = parseOverpassResponse(response);
+    expect(pois[0].name).toBeNull();
+    expect(pois[0].openingHours).toBeNull();
+    expect(pois[0].acceptsCards).toBeNull();
+  });
+
+  // Slice 5: detects card payment from various OSM payment tags
+  it('detects card payment from various payment tags', () => {
+    const makeElement = (tags: Record<string, string>) => ({
+      id: 1,
+      type: 'node' as const,
+      lat: 50,
+      lon: 20,
+      tags: { amenity: 'fuel', ...tags },
+    });
+
+    // credit_cards=yes
+    expect(
+      parseOverpassResponse({
+        elements: [makeElement({ 'payment:credit_cards': 'yes' })],
+      })[0].acceptsCards,
+    ).toBe(true);
+
+    // debit_cards=yes
+    expect(
+      parseOverpassResponse({
+        elements: [makeElement({ 'payment:debit_cards': 'yes' })],
+      })[0].acceptsCards,
+    ).toBe(true);
+
+    // visa=yes
+    expect(
+      parseOverpassResponse({
+        elements: [makeElement({ 'payment:visa': 'yes' })],
+      })[0].acceptsCards,
+    ).toBe(true);
+
+    // mastercard=yes
+    expect(
+      parseOverpassResponse({
+        elements: [makeElement({ 'payment:mastercard': 'yes' })],
+      })[0].acceptsCards,
+    ).toBe(true);
+
+    // credit_cards=no
+    expect(
+      parseOverpassResponse({
+        elements: [makeElement({ 'payment:credit_cards': 'no' })],
+      })[0].acceptsCards,
+    ).toBe(false);
+
+    // no payment tags
+    expect(
+      parseOverpassResponse({
+        elements: [makeElement({})],
+      })[0].acceptsCards,
+    ).toBeNull();
+  });
+
+  // Handles way/relation elements with center coordinates
+  it('uses center coords for ways and relations', () => {
+    const response: OverpassResponse = {
+      elements: [
+        {
+          id: 789,
+          type: 'way',
+          center: { lat: 50.3, lon: 20.3 },
+          tags: { shop: 'supermarket', name: 'Lidl' },
+        },
+      ],
+    };
+
+    const pois = parseOverpassResponse(response);
+    expect(pois[0].lat).toBe(50.3);
+    expect(pois[0].lng).toBe(20.3);
+    expect(pois[0].type).toBe('supermarket');
+  });
+});
+
+describe('fetchPOIs', () => {
+  // Slice 6: calls client with built query and returns parsed result
+  it('calls client and returns parsed POIs', async () => {
+    const mockResponse: OverpassResponse = {
+      elements: [
+        {
+          id: 1,
+          type: 'node',
+          lat: 50,
+          lon: 20,
+          tags: { amenity: 'fuel', name: 'Test Station' },
+        },
+      ],
+    };
+
+    const client: OverpassClient = {
+      query: vi.fn().mockResolvedValue(mockResponse),
+    };
+
+    const points = makePoints(3);
+    const pois = await fetchPOIs(points, client);
+
+    expect(client.query).toHaveBeenCalledOnce();
+    const queryArg = vi.mocked(client.query).mock.calls[0][0];
+    expect(queryArg).toContain('"amenity"="fuel"');
+
+    expect(pois).toHaveLength(1);
+    expect(pois[0].name).toBe('Test Station');
+  });
+
+  // Slice 7: wraps client errors in descriptive message
+  it('wraps client errors with descriptive message', async () => {
+    const client: OverpassClient = {
+      query: vi.fn().mockRejectedValue(new Error('Network timeout')),
+    };
+
+    const points = makePoints(3);
+    await expect(fetchPOIs(points, client)).rejects.toThrow(
+      'Failed to fetch POIs: Network timeout',
+    );
+  });
+});

--- a/src/poi-fetcher.ts
+++ b/src/poi-fetcher.ts
@@ -1,0 +1,153 @@
+import type { RoutePoint } from './gpx-parser';
+
+export type POIType =
+  | 'fuel'
+  | 'convenience'
+  | 'supermarket'
+  | 'bakery'
+  | 'restaurant'
+  | 'cafe';
+
+export interface POI {
+  id: number;
+  name: string | null;
+  type: POIType;
+  lat: number;
+  lng: number;
+  openingHours: string | null;
+  acceptsCards: boolean | null;
+}
+
+export interface OverpassElement {
+  id: number;
+  type: string;
+  lat?: number;
+  lon?: number;
+  center?: { lat: number; lon: number };
+  tags?: Record<string, string>;
+}
+
+export interface OverpassResponse {
+  elements: OverpassElement[];
+}
+
+export interface OverpassClient {
+  query(overpassQL: string): Promise<OverpassResponse>;
+}
+
+const POI_FILTERS = [
+  ['amenity', 'fuel'],
+  ['shop', 'convenience'],
+  ['shop', 'supermarket'],
+  ['shop', 'bakery'],
+  ['amenity', 'restaurant'],
+  ['amenity', 'cafe'],
+] as const;
+
+const MAX_SAMPLE_POINTS = 50;
+
+export function buildOverpassQuery(points: RoutePoint[]): string {
+  const sampled = samplePoints(points);
+  const coords = sampled.map((p) => `${p.lat},${p.lng}`).join(',');
+
+  const filters = POI_FILTERS.map(
+    ([key, value]) => `  nwr["${key}"="${value}"](around:300,${coords});`,
+  ).join('\n');
+
+  return `[out:json][timeout:30];
+(
+${filters}
+);
+out center body;`;
+}
+
+function samplePoints(points: RoutePoint[]): RoutePoint[] {
+  if (points.length <= MAX_SAMPLE_POINTS) return points;
+
+  const step = (points.length - 1) / (MAX_SAMPLE_POINTS - 1);
+  const sampled: RoutePoint[] = [];
+  for (let i = 0; i < MAX_SAMPLE_POINTS; i++) {
+    sampled.push(points[Math.round(i * step)]);
+  }
+  return sampled;
+}
+
+const TAG_TO_TYPE: Record<string, POIType> = {
+  fuel: 'fuel',
+  convenience: 'convenience',
+  supermarket: 'supermarket',
+  bakery: 'bakery',
+  restaurant: 'restaurant',
+  cafe: 'cafe',
+};
+
+const CARD_TAGS = [
+  'payment:credit_cards',
+  'payment:debit_cards',
+  'payment:visa',
+  'payment:mastercard',
+];
+
+export function parseOverpassResponse(response: OverpassResponse): POI[] {
+  return response.elements.map((el) => {
+    const tags = el.tags ?? {};
+    const lat = el.lat ?? el.center?.lat ?? 0;
+    const lng = el.lon ?? el.center?.lon ?? 0;
+
+    return {
+      id: el.id,
+      name: tags.name ?? null,
+      type: resolveType(tags),
+      lat,
+      lng,
+      openingHours: tags.opening_hours ?? null,
+      acceptsCards: resolveCards(tags),
+    };
+  });
+}
+
+function resolveType(tags: Record<string, string>): POIType {
+  const amenity = tags.amenity;
+  const shop = tags.shop;
+  if (amenity && TAG_TO_TYPE[amenity]) return TAG_TO_TYPE[amenity];
+  if (shop && TAG_TO_TYPE[shop]) return TAG_TO_TYPE[shop];
+  return 'fuel'; // fallback
+}
+
+function resolveCards(tags: Record<string, string>): boolean | null {
+  for (const key of CARD_TAGS) {
+    if (key in tags) {
+      return tags[key] === 'yes';
+    }
+  }
+  return null;
+}
+
+export function createOverpassClient(): OverpassClient {
+  return {
+    async query(overpassQL: string) {
+      const res = await fetch('https://overpass-api.de/api/interpreter', {
+        method: 'POST',
+        body: `data=${encodeURIComponent(overpassQL)}`,
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      });
+      if (!res.ok) throw new Error(`Overpass API error: ${res.status}`);
+      return res.json();
+    },
+  };
+}
+
+export async function fetchPOIs(
+  points: RoutePoint[],
+  client: OverpassClient,
+): Promise<POI[]> {
+  const query = buildOverpassQuery(points);
+  try {
+    const response = await client.query(query);
+    return parseOverpassResponse(response);
+  } catch (err) {
+    throw new Error(
+      `Failed to fetch POIs: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+}

--- a/src/route-map.test.ts
+++ b/src/route-map.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import type { LeafletFactory, RouteMapHandle } from './route-map';
 import { initRouteMap } from './route-map';
 import type { ParsedRoute } from './gpx-parser';
+import type { POI } from './poi-fetcher';
 
 function makeRoute(
   points: Array<{ lat: number; lng: number }>,
@@ -29,7 +30,7 @@ function createMockFactory() {
 
   const polylines: Array<{ addTo: ReturnType<typeof vi.fn>; remove: ReturnType<typeof vi.fn>; getBounds: ReturnType<typeof vi.fn> }> = [];
   const markers: Array<{ addTo: ReturnType<typeof vi.fn>; remove: ReturnType<typeof vi.fn> }> = [];
-  const circleMarkers: Array<{ addTo: ReturnType<typeof vi.fn>; remove: ReturnType<typeof vi.fn>; setLatLng: ReturnType<typeof vi.fn> }> = [];
+  const circleMarkers: Array<{ addTo: ReturnType<typeof vi.fn>; remove: ReturnType<typeof vi.fn>; setLatLng: ReturnType<typeof vi.fn>; bindPopup: ReturnType<typeof vi.fn> }> = [];
 
   const factory: LeafletFactory = {
     map: vi.fn(() => mockMap) as unknown as LeafletFactory['map'],
@@ -55,6 +56,7 @@ function createMockFactory() {
         addTo: vi.fn().mockReturnThis(),
         remove: vi.fn(),
         setLatLng: vi.fn().mockReturnThis(),
+        bindPopup: vi.fn().mockReturnThis(),
       };
       circleMarkers.push(cm);
       return cm;
@@ -312,5 +314,70 @@ describe('route-map', () => {
 
     const banner = container.querySelector('.off-route-warning') as HTMLElement;
     expect(banner.hidden).toBe(true);
+  });
+
+  // Slice 8: showPOIs adds circle markers with category-specific colors
+  it('showPOIs adds circle markers for each POI with correct colors', () => {
+    const pois: POI[] = [
+      { id: 1, name: 'Shell', type: 'fuel', lat: 50.1, lng: 20.1, openingHours: null, acceptsCards: true },
+      { id: 2, name: 'Cafe X', type: 'cafe', lat: 50.2, lng: 20.2, openingHours: null, acceptsCards: null },
+    ];
+
+    handle.showPOIs(pois);
+
+    expect(mocks.factory.circleMarker).toHaveBeenCalledTimes(2);
+    const calls = vi.mocked(mocks.factory.circleMarker).mock.calls;
+    expect(calls[0][0]).toEqual([50.1, 20.1]);
+    expect(calls[0][1]).toMatchObject({ color: '#ef4444' }); // fuel = red
+    expect(calls[1][0]).toEqual([50.2, 20.2]);
+    expect(calls[1][1]).toMatchObject({ color: '#6366f1' }); // cafe = indigo
+  });
+
+  // Slice 9: showPOIs binds popups with name, type, and card info
+  it('showPOIs binds popups with name, type, and card info', () => {
+    const pois: POI[] = [
+      { id: 1, name: 'Shell', type: 'fuel', lat: 50.1, lng: 20.1, openingHours: 'Mo-Su 06:00-22:00', acceptsCards: true },
+    ];
+
+    handle.showPOIs(pois);
+
+    const cm = mocks.circleMarkers[0];
+    expect(cm.bindPopup).toHaveBeenCalledOnce();
+    const popupHtml = cm.bindPopup.mock.calls[0][0] as string;
+    expect(popupHtml).toContain('Shell');
+    expect(popupHtml).toContain('fuel');
+    expect(popupHtml).toContain('Cards: Yes');
+  });
+
+  // Slice 10: clearPOIs removes all POI markers
+  it('clearPOIs removes all POI markers', () => {
+    const pois: POI[] = [
+      { id: 1, name: 'A', type: 'fuel', lat: 50, lng: 20, openingHours: null, acceptsCards: null },
+      { id: 2, name: 'B', type: 'cafe', lat: 51, lng: 21, openingHours: null, acceptsCards: null },
+    ];
+
+    handle.showPOIs(pois);
+    handle.clearPOIs();
+
+    for (const cm of mocks.circleMarkers) {
+      expect(cm.remove).toHaveBeenCalledOnce();
+    }
+  });
+
+  // Slice 11: calling showPOIs again replaces previous markers
+  it('showPOIs replaces previous POI markers', () => {
+    const pois1: POI[] = [
+      { id: 1, name: 'A', type: 'fuel', lat: 50, lng: 20, openingHours: null, acceptsCards: null },
+    ];
+    const pois2: POI[] = [
+      { id: 2, name: 'B', type: 'cafe', lat: 51, lng: 21, openingHours: null, acceptsCards: null },
+    ];
+
+    handle.showPOIs(pois1);
+    const firstMarker = mocks.circleMarkers[0];
+    expect(firstMarker.remove).not.toHaveBeenCalled();
+
+    handle.showPOIs(pois2);
+    expect(firstMarker.remove).toHaveBeenCalledOnce();
   });
 });

--- a/src/route-map.ts
+++ b/src/route-map.ts
@@ -1,4 +1,5 @@
 import type { ParsedRoute } from './gpx-parser';
+import type { POI, POIType } from './poi-fetcher';
 import type * as L from 'leaflet';
 
 export interface RouteMapHandle {
@@ -9,6 +10,8 @@ export interface RouteMapHandle {
   clearRiderPosition(): void;
   showOffRouteWarning(): void;
   hideOffRouteWarning(): void;
+  showPOIs(pois: POI[]): void;
+  clearPOIs(): void;
 }
 
 export interface LeafletFactory {
@@ -24,6 +27,15 @@ export interface LeafletFactory {
     options?: L.CircleMarkerOptions,
   ): L.CircleMarker;
 }
+
+const POI_COLORS: Record<POIType, string> = {
+  fuel: '#ef4444',
+  convenience: '#22c55e',
+  supermarket: '#22c55e',
+  bakery: '#f59e0b',
+  restaurant: '#8b5cf6',
+  cafe: '#6366f1',
+};
 
 const DEFAULT_CENTER: L.LatLngExpression = [0, 0];
 const DEFAULT_ZOOM = 2;
@@ -159,6 +171,42 @@ export function initRouteMap(
     offRouteBanner.hidden = true;
   }
 
+  let poiMarkers: L.CircleMarker[] = [];
+
+  function clearPOIs(): void {
+    for (const m of poiMarkers) {
+      m.remove();
+    }
+    poiMarkers = [];
+  }
+
+  function showPOIs(pois: POI[]): void {
+    clearPOIs();
+    for (const poi of pois) {
+      const color = POI_COLORS[poi.type];
+      const cm = leaflet
+        .circleMarker([poi.lat, poi.lng], {
+          radius: 6,
+          color,
+          fillColor: color,
+          fillOpacity: 0.8,
+          weight: 2,
+        })
+        .addTo(map);
+
+      const cardText =
+        poi.acceptsCards === true
+          ? 'Cards: Yes'
+          : poi.acceptsCards === false
+            ? 'Cards: No'
+            : 'Cards: Unknown';
+      const popupHtml = `<strong>${poi.name ?? 'Unnamed'}</strong><br>${poi.type}<br>${cardText}`;
+      cm.bindPopup(popupHtml);
+
+      poiMarkers.push(cm);
+    }
+  }
+
   // Initial state: placeholder visible, map hidden
   mapDiv.hidden = true;
 
@@ -170,6 +218,8 @@ export function initRouteMap(
     clearRiderPosition,
     showOffRouteWarning,
     hideOffRouteWarning,
+    showPOIs,
+    clearPOIs,
   };
 }
 

--- a/src/upload.test.ts
+++ b/src/upload.test.ts
@@ -16,6 +16,8 @@ function setupDOM(): void {
       </section>
       <p id="error-display" hidden></p>
       <button id="clear-btn" type="button" hidden>Clear route</button>
+      <button id="refresh-btn" type="button" hidden>Refresh stops</button>
+      <p id="loading-indicator" hidden>Loading stops…</p>
       <div id="map-container"></div>
     </div>
   `;
@@ -50,6 +52,8 @@ vi.mock('./route-map', () => {
   const clearRiderPosition = vi.fn();
   const showOffRouteWarning = vi.fn();
   const hideOffRouteWarning = vi.fn();
+  const showPOIs = vi.fn();
+  const clearPOIs = vi.fn();
   return {
     initRouteMap: vi.fn(() => ({
       showRoute,
@@ -59,8 +63,20 @@ vi.mock('./route-map', () => {
       clearRiderPosition,
       showOffRouteWarning,
       hideOffRouteWarning,
+      showPOIs,
+      clearPOIs,
     })),
     setDefaultFactory: vi.fn(),
+  };
+});
+
+// Mock poi-fetcher module
+vi.mock('./poi-fetcher', () => {
+  return {
+    fetchPOIs: vi.fn().mockResolvedValue([
+      { id: 1, name: 'Test POI', type: 'fuel', lat: 50, lng: 20, openingHours: null, acceptsCards: null },
+    ]),
+    createOverpassClient: vi.fn(() => ({ query: vi.fn() })),
   };
 });
 
@@ -263,5 +279,91 @@ describe('upload GPS integration', () => {
     await flushFileReader();
 
     expect(handle.showRoute).toHaveBeenCalledOnce();
+  });
+});
+
+describe('upload refresh button', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    setupDOM();
+    vi.clearAllMocks();
+  });
+
+  // Slice 12: Refresh button visible when route is loaded, hidden when cleared
+  it('shows refresh button when route loaded, hides on clear', async () => {
+    initUpload();
+    const refreshBtn = document.getElementById('refresh-btn') as HTMLButtonElement;
+
+    expect(refreshBtn.hidden).toBe(true);
+
+    simulateFileUpload(MINIMAL_2_TRKPT);
+    await flushFileReader();
+
+    expect(refreshBtn.hidden).toBe(false);
+
+    const clearBtn = document.getElementById('clear-btn') as HTMLButtonElement;
+    clearBtn.click();
+
+    expect(refreshBtn.hidden).toBe(true);
+  });
+
+  // Slice 13: Refresh button triggers POI fetch and displays results on map
+  it('clicking refresh fetches POIs and shows on map', async () => {
+    const { initRouteMap } = await import('./route-map');
+    const { fetchPOIs } = await import('./poi-fetcher');
+    initUpload();
+    const handle = vi.mocked(initRouteMap).mock.results[0].value;
+
+    simulateFileUpload(MINIMAL_2_TRKPT);
+    await flushFileReader();
+
+    const refreshBtn = document.getElementById('refresh-btn') as HTMLButtonElement;
+    refreshBtn.click();
+
+    // Wait for async fetch
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(fetchPOIs).toHaveBeenCalledOnce();
+    expect(handle.showPOIs).toHaveBeenCalledOnce();
+  });
+
+  // Slice 14: Loading indicator shown during fetch, hidden after
+  it('shows loading indicator during fetch', async () => {
+    initUpload();
+    const loading = document.getElementById('loading-indicator') as HTMLElement;
+
+    simulateFileUpload(MINIMAL_2_TRKPT);
+    await flushFileReader();
+
+    expect(loading.hidden).toBe(true);
+
+    const refreshBtn = document.getElementById('refresh-btn') as HTMLButtonElement;
+    refreshBtn.click();
+
+    // Loading should eventually be hidden after fetch completes
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(loading.hidden).toBe(true);
+  });
+
+  // Slice 15: Error state on fetch failure
+  it('shows error on fetch failure and hides loading', async () => {
+    const { fetchPOIs } = await import('./poi-fetcher');
+    vi.mocked(fetchPOIs).mockRejectedValueOnce(new Error('Overpass API error'));
+
+    initUpload();
+
+    simulateFileUpload(MINIMAL_2_TRKPT);
+    await flushFileReader();
+
+    const refreshBtn = document.getElementById('refresh-btn') as HTMLButtonElement;
+    refreshBtn.click();
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    const loading = document.getElementById('loading-indicator') as HTMLElement;
+    const errorDisplay = document.getElementById('error-display') as HTMLElement;
+    expect(loading.hidden).toBe(true);
+    expect(errorDisplay.hidden).toBe(false);
+    expect(errorDisplay.textContent).toContain('Overpass API error');
   });
 });

--- a/src/upload.ts
+++ b/src/upload.ts
@@ -3,12 +3,16 @@ import type { ParsedRoute } from './gpx-parser';
 import { initRouteMap } from './route-map';
 import { initGpsTracker } from './gps-tracker';
 import type { GeolocationProvider, GpsTrackerHandle } from './gps-tracker';
+import { fetchPOIs, createOverpassClient } from './poi-fetcher';
+import type { OverpassClient } from './poi-fetcher';
 
 const STORAGE_KEY = 'fuelspot-gpx';
 
-export function initUpload(geo?: GeolocationProvider): void {
+export function initUpload(geo?: GeolocationProvider, overpassClient?: OverpassClient): void {
   const fileInput = document.getElementById('gpx-input') as HTMLInputElement;
   const clearBtn = document.getElementById('clear-btn') as HTMLButtonElement;
+  const refreshBtn = document.getElementById('refresh-btn') as HTMLButtonElement;
+  const loadingIndicator = document.getElementById('loading-indicator') as HTMLElement;
   const statsSection = document.getElementById('route-stats') as HTMLElement;
   const errorSection = document.getElementById('error-display') as HTMLElement;
   const routeName = document.getElementById('route-name') as HTMLElement;
@@ -17,8 +21,10 @@ export function initUpload(geo?: GeolocationProvider): void {
   const mapContainer = document.getElementById('map-container') as HTMLElement;
 
   const mapHandle = initRouteMap(mapContainer);
+  const client = overpassClient ?? createOverpassClient();
 
   let gpsTracker: GpsTrackerHandle | null = null;
+  let currentRoute: ParsedRoute | null = null;
 
   const geoProvider = geo ?? (typeof navigator !== 'undefined' && navigator.geolocation
     ? navigator.geolocation
@@ -40,12 +46,14 @@ export function initUpload(geo?: GeolocationProvider): void {
   }
 
   function showRoute(route: ParsedRoute): void {
+    currentRoute = route;
     routeName.textContent = route.name ?? 'Unnamed route';
     pointCount.textContent = `${route.points.length} points`;
     routeDistance.textContent = `${(route.totalDistance / 1000).toFixed(1)} km`;
     statsSection.hidden = false;
     errorSection.hidden = true;
     clearBtn.hidden = false;
+    refreshBtn.hidden = false;
     mapHandle.showRoute(route);
     gpsTracker?.start(route.points);
   }
@@ -57,11 +65,14 @@ export function initUpload(geo?: GeolocationProvider): void {
   }
 
   function resetUI(): void {
+    currentRoute = null;
     statsSection.hidden = true;
     errorSection.hidden = true;
     clearBtn.hidden = true;
+    refreshBtn.hidden = true;
     fileInput.value = '';
     mapHandle.clear();
+    mapHandle.clearPOIs();
     gpsTracker?.stop();
     mapHandle.clearRiderPosition();
     mapHandle.hideOffRouteWarning();
@@ -98,5 +109,22 @@ export function initUpload(geo?: GeolocationProvider): void {
   clearBtn.addEventListener('click', () => {
     localStorage.removeItem(STORAGE_KEY);
     resetUI();
+  });
+
+  refreshBtn.addEventListener('click', () => {
+    if (!currentRoute) return;
+    loadingIndicator.hidden = false;
+    errorSection.hidden = true;
+
+    fetchPOIs(currentRoute.points, client)
+      .then((pois) => {
+        mapHandle.showPOIs(pois);
+      })
+      .catch((err) => {
+        showError(err instanceof Error ? err.message : 'Failed to load stops');
+      })
+      .finally(() => {
+        loadingIndicator.hidden = true;
+      });
   });
 }


### PR DESCRIPTION
## Summary

- Add `poi-fetcher.ts` module: builds Overpass QL queries for 6 POI categories (fuel, convenience, supermarket, bakery, restaurant, cafe), parses responses with card payment detection, and fetches POIs via injected client
- Extend `route-map.ts` with `showPOIs`/`clearPOIs`: color-coded circle markers (red=fuel, green=store, amber=bakery, purple=restaurant, indigo=cafe) with popups showing name, type, and card acceptance
- Wire refresh button in `upload.ts` with loading indicator and error handling
- Add `#refresh-btn` and `#loading-indicator` to `index.html`

**Note:** This branch builds on `feat/gps-route-matcher` (GPS tracking, issue #4). Merge that branch first.

## Test plan

- [x] 8 new tests for `poi-fetcher`: query building, point sampling, response parsing, optional field defaults, payment tag detection, client orchestration, error wrapping
- [x] 4 new tests for `route-map`: POI pin display, popup binding, marker clearing, marker replacement
- [x] 4 new tests for `upload`: refresh button visibility, POI fetch trigger, loading indicator, error state
- [x] All 78 tests pass (`npm run test:run`)
- [x] Build passes clean (`npm run build`)
- [ ] Manual: `npm run dev` → upload GPX → click Refresh → POI pins appear on map with popups

🤖 Generated with [Claude Code](https://claude.com/claude-code)