### PR TITLE
feat: add Overpass API 429 retry, debounce & cache

### DIFF
--- a/src/poi-fetcher.test.ts
+++ b/src/poi-fetcher.test.ts
@@ -4,6 +4,8 @@ import {
   buildOverpassQuery,
   parseOverpassResponse,
   fetchPOIs,
+  createOverpassClient,
+  createCachedFetcher,
 } from './poi-fetcher';
 import type { OverpassClient, OverpassResponse } from './poi-fetcher';
 
@@ -223,5 +225,132 @@ describe('fetchPOIs', () => {
     await expect(fetchPOIs(points, client)).rejects.toThrow(
       'Failed to fetch POIs: Network timeout',
     );
+  });
+});
+
+describe('createOverpassClient retry', () => {
+  const validResponse = { elements: [] };
+  const noDelay = () => Promise.resolve();
+
+  it('retries on 429 then resolves with data', async () => {
+    const mockFetch = vi.fn()
+      .mockResolvedValueOnce({ ok: false, status: 429 })
+      .mockResolvedValueOnce({ ok: false, status: 429 })
+      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve(validResponse) });
+    vi.stubGlobal('fetch', mockFetch);
+
+    const client = createOverpassClient({ delayFn: noDelay });
+    const result = await client.query('test');
+
+    expect(result).toEqual(validResponse);
+    expect(mockFetch).toHaveBeenCalledTimes(3);
+
+    vi.unstubAllGlobals();
+  });
+
+  it('rejects with friendly message after max retries exceeded', async () => {
+    const mockFetch = vi.fn().mockResolvedValue({ ok: false, status: 429 });
+    vi.stubGlobal('fetch', mockFetch);
+
+    const client = createOverpassClient({ maxRetries: 3, delayFn: noDelay });
+
+    await expect(client.query('test')).rejects.toThrow(
+      'Overpass API is busy — please try again in a minute',
+    );
+    expect(mockFetch).toHaveBeenCalledTimes(4); // 1 initial + 3 retries
+
+    vi.unstubAllGlobals();
+  });
+
+  it('rejects immediately on non-429 errors without retry', async () => {
+    const mockFetch = vi.fn().mockResolvedValue({ ok: false, status: 500 });
+    vi.stubGlobal('fetch', mockFetch);
+
+    const client = createOverpassClient({ delayFn: noDelay });
+
+    await expect(client.query('test')).rejects.toThrow('Overpass API error: 500');
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+
+    vi.unstubAllGlobals();
+  });
+
+  it('calls delayFn with exponential backoff delays', async () => {
+    const mockFetch = vi.fn()
+      .mockResolvedValueOnce({ ok: false, status: 429 })
+      .mockResolvedValueOnce({ ok: false, status: 429 })
+      .mockResolvedValueOnce({ ok: false, status: 429 })
+      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve(validResponse) });
+    vi.stubGlobal('fetch', mockFetch);
+
+    const delaySpy = vi.fn(() => Promise.resolve());
+    const client = createOverpassClient({ baseDelay: 1000, delayFn: delaySpy });
+    await client.query('test');
+
+    expect(delaySpy).toHaveBeenCalledTimes(3);
+    expect(delaySpy).toHaveBeenNthCalledWith(1, 1000);
+    expect(delaySpy).toHaveBeenNthCalledWith(2, 2000);
+    expect(delaySpy).toHaveBeenNthCalledWith(3, 4000);
+
+    vi.unstubAllGlobals();
+  });
+});
+
+describe('createCachedFetcher', () => {
+  it('returns cached result for same points', async () => {
+    const client: OverpassClient = {
+      query: vi.fn().mockResolvedValue({ elements: [
+        { id: 1, type: 'node', lat: 50, lon: 20, tags: { amenity: 'fuel', name: 'Test' } },
+      ] }),
+    };
+    const points = makePoints(3);
+    const cached = createCachedFetcher(client);
+
+    const first = await cached.fetch(points);
+    const second = await cached.fetch(points);
+
+    expect(client.query).toHaveBeenCalledTimes(1);
+    expect(first).toEqual(second);
+  });
+
+  it('re-fetches after TTL expires', async () => {
+    vi.useFakeTimers();
+    const client: OverpassClient = {
+      query: vi.fn().mockResolvedValue({ elements: [] }),
+    };
+    const points = makePoints(3);
+    const cached = createCachedFetcher(client, 5 * 60 * 1000); // 5 min TTL
+
+    await cached.fetch(points);
+    vi.advanceTimersByTime(6 * 60 * 1000); // advance 6 min
+    await cached.fetch(points);
+
+    expect(client.query).toHaveBeenCalledTimes(2);
+    vi.useRealTimers();
+  });
+
+  it('fetches separately for different points', async () => {
+    const client: OverpassClient = {
+      query: vi.fn().mockResolvedValue({ elements: [] }),
+    };
+    const cached = createCachedFetcher(client);
+
+    await cached.fetch(makePoints(3));
+    await cached.fetch(makePoints(5));
+
+    expect(client.query).toHaveBeenCalledTimes(2);
+  });
+
+  it('clears cache so next call hits API again', async () => {
+    const client: OverpassClient = {
+      query: vi.fn().mockResolvedValue({ elements: [] }),
+    };
+    const points = makePoints(3);
+    const cached = createCachedFetcher(client);
+
+    await cached.fetch(points);
+    cached.clear();
+    await cached.fetch(points);
+
+    expect(client.query).toHaveBeenCalledTimes(2);
   });
 });

--- a/src/poi-fetcher.ts
+++ b/src/poi-fetcher.ts
@@ -123,16 +123,67 @@ function resolveCards(tags: Record<string, string>): boolean | null {
   return null;
 }
 
-export function createOverpassClient(): OverpassClient {
+export interface OverpassClientOptions {
+  maxRetries?: number;
+  baseDelay?: number;
+  delayFn?: (ms: number) => Promise<void>;
+}
+
+const defaultDelay = (ms: number) => new Promise<void>((r) => setTimeout(r, ms));
+
+export function createOverpassClient(options?: OverpassClientOptions): OverpassClient {
+  const maxRetries = options?.maxRetries ?? 3;
+  const baseDelay = options?.baseDelay ?? 1000;
+  const delayFn = options?.delayFn ?? defaultDelay;
+
   return {
     async query(overpassQL: string) {
-      const res = await fetch('https://overpass-api.de/api/interpreter', {
-        method: 'POST',
-        body: `data=${encodeURIComponent(overpassQL)}`,
-        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-      });
-      if (!res.ok) throw new Error(`Overpass API error: ${res.status}`);
-      return res.json();
+      let retries = 0;
+      while (true) {
+        const res = await fetch('https://overpass-api.de/api/interpreter', {
+          method: 'POST',
+          body: `data=${encodeURIComponent(overpassQL)}`,
+          headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+        });
+        if (res.ok) return res.json();
+        if (res.status !== 429 || retries >= maxRetries) {
+          if (res.status === 429) {
+            throw new Error('Overpass API is busy — please try again in a minute');
+          }
+          throw new Error(`Overpass API error: ${res.status}`);
+        }
+        await delayFn(baseDelay * 2 ** retries);
+        retries++;
+      }
+    },
+  };
+}
+
+export interface CachedFetcher {
+  fetch(points: RoutePoint[]): Promise<POI[]>;
+  clear(): void;
+}
+
+export function createCachedFetcher(
+  client: OverpassClient,
+  ttl: number = 5 * 60 * 1000,
+): CachedFetcher {
+  const cache = new Map<string, { pois: POI[]; timestamp: number }>();
+
+  return {
+    async fetch(points: RoutePoint[]): Promise<POI[]> {
+      const query = buildOverpassQuery(points);
+      const entry = cache.get(query);
+      if (entry && Date.now() - entry.timestamp < ttl) {
+        return entry.pois;
+      }
+      const response = await client.query(query);
+      const pois = parseOverpassResponse(response);
+      cache.set(query, { pois, timestamp: Date.now() });
+      return pois;
+    },
+    clear() {
+      cache.clear();
     },
   };
 }

--- a/src/upload.test.ts
+++ b/src/upload.test.ts
@@ -71,12 +71,19 @@ vi.mock('./route-map', () => {
 });
 
 // Mock poi-fetcher module
+const mockFetch = vi.fn().mockResolvedValue([
+  { id: 1, name: 'Test POI', type: 'fuel', lat: 50, lng: 20, openingHours: null, acceptsCards: null },
+]);
 vi.mock('./poi-fetcher', () => {
   return {
     fetchPOIs: vi.fn().mockResolvedValue([
       { id: 1, name: 'Test POI', type: 'fuel', lat: 50, lng: 20, openingHours: null, acceptsCards: null },
     ]),
     createOverpassClient: vi.fn(() => ({ query: vi.fn() })),
+    createCachedFetcher: vi.fn(() => ({
+      fetch: mockFetch,
+      clear: vi.fn(),
+    })),
   };
 });
 
@@ -310,7 +317,6 @@ describe('upload refresh button', () => {
   // Slice 13: Refresh button triggers POI fetch and displays results on map
   it('clicking refresh fetches POIs and shows on map', async () => {
     const { initRouteMap } = await import('./route-map');
-    const { fetchPOIs } = await import('./poi-fetcher');
     initUpload();
     const handle = vi.mocked(initRouteMap).mock.results[0].value;
 
@@ -323,7 +329,7 @@ describe('upload refresh button', () => {
     // Wait for async fetch
     await new Promise((resolve) => setTimeout(resolve, 0));
 
-    expect(fetchPOIs).toHaveBeenCalledOnce();
+    expect(mockFetch).toHaveBeenCalledOnce();
     expect(handle.showPOIs).toHaveBeenCalledOnce();
   });
 
@@ -347,8 +353,7 @@ describe('upload refresh button', () => {
 
   // Slice 15: Error state on fetch failure
   it('shows error on fetch failure and hides loading', async () => {
-    const { fetchPOIs } = await import('./poi-fetcher');
-    vi.mocked(fetchPOIs).mockRejectedValueOnce(new Error('Overpass API error'));
+    mockFetch.mockRejectedValueOnce(new Error('Overpass API error'));
 
     initUpload();
 
@@ -365,5 +370,71 @@ describe('upload refresh button', () => {
     expect(loading.hidden).toBe(true);
     expect(errorDisplay.hidden).toBe(false);
     expect(errorDisplay.textContent).toContain('Overpass API error');
+  });
+
+  // Cycle 3: Debounce — two clicks while in-flight only fetches once
+  it('ignores clicks while fetch is in-flight', async () => {
+    let resolveFetch!: (value: unknown[]) => void;
+    mockFetch.mockImplementation(
+      () => new Promise((resolve) => { resolveFetch = resolve; }),
+    );
+
+    initUpload();
+
+    simulateFileUpload(MINIMAL_2_TRKPT);
+    await flushFileReader();
+
+    const refreshBtn = document.getElementById('refresh-btn') as HTMLButtonElement;
+    refreshBtn.click(); // first click — starts fetch
+    refreshBtn.click(); // second click — should be ignored
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+
+    // Complete the fetch
+    resolveFetch([]);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  });
+
+  // Cycle 3: Button re-enabled after fetch completes
+  it('re-enables refresh button after fetch completes', async () => {
+    let resolveFetch!: (value: unknown[]) => void;
+    mockFetch.mockImplementation(
+      () => new Promise((resolve) => { resolveFetch = resolve; }),
+    );
+
+    initUpload();
+
+    simulateFileUpload(MINIMAL_2_TRKPT);
+    await flushFileReader();
+
+    const refreshBtn = document.getElementById('refresh-btn') as HTMLButtonElement;
+    refreshBtn.click();
+
+    expect(refreshBtn.disabled).toBe(true);
+
+    resolveFetch([]);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(refreshBtn.disabled).toBe(false);
+  });
+
+  // Cycle 4: Friendly error message displayed in UI
+  it('shows friendly error from retry exhaustion', async () => {
+    mockFetch.mockRejectedValueOnce(
+      new Error('Failed to fetch POIs: Overpass API is busy — please try again in a minute'),
+    );
+
+    initUpload();
+
+    simulateFileUpload(MINIMAL_2_TRKPT);
+    await flushFileReader();
+
+    const refreshBtn = document.getElementById('refresh-btn') as HTMLButtonElement;
+    refreshBtn.click();
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    const errorDisplay = document.getElementById('error-display') as HTMLElement;
+    expect(errorDisplay.textContent).toContain('try again');
   });
 });

--- a/src/upload.ts
+++ b/src/upload.ts
@@ -3,7 +3,7 @@ import type { ParsedRoute } from './gpx-parser';
 import { initRouteMap } from './route-map';
 import { initGpsTracker } from './gps-tracker';
 import type { GeolocationProvider, GpsTrackerHandle } from './gps-tracker';
-import { fetchPOIs, createOverpassClient } from './poi-fetcher';
+import { createOverpassClient, createCachedFetcher } from './poi-fetcher';
 import type { OverpassClient } from './poi-fetcher';
 
 const STORAGE_KEY = 'fuelspot-gpx';
@@ -22,6 +22,7 @@ export function initUpload(geo?: GeolocationProvider, overpassClient?: OverpassC
 
   const mapHandle = initRouteMap(mapContainer);
   const client = overpassClient ?? createOverpassClient();
+  const cachedFetcher = createCachedFetcher(client);
 
   let gpsTracker: GpsTrackerHandle | null = null;
   let currentRoute: ParsedRoute | null = null;
@@ -76,6 +77,7 @@ export function initUpload(geo?: GeolocationProvider, overpassClient?: OverpassC
     gpsTracker?.stop();
     mapHandle.clearRiderPosition();
     mapHandle.hideOffRouteWarning();
+    cachedFetcher.clear();
   }
 
   // Load from localStorage on init
@@ -112,11 +114,12 @@ export function initUpload(geo?: GeolocationProvider, overpassClient?: OverpassC
   });
 
   refreshBtn.addEventListener('click', () => {
-    if (!currentRoute) return;
+    if (!currentRoute || refreshBtn.disabled) return;
+    refreshBtn.disabled = true;
     loadingIndicator.hidden = false;
     errorSection.hidden = true;
 
-    fetchPOIs(currentRoute.points, client)
+    cachedFetcher.fetch(currentRoute.points)
       .then((pois) => {
         mapHandle.showPOIs(pois);
       })
@@ -125,6 +128,7 @@ export function initUpload(geo?: GeolocationProvider, overpassClient?: OverpassC
       })
       .finally(() => {
         loadingIndicator.hidden = true;
+        refreshBtn.disabled = false;
       });
   });
 }


### PR DESCRIPTION
## Summary

- **Retry with exponential backoff** on Overpass API 429 responses (up to 3 retries, 1s/2s/4s delays) with friendly user-facing error after exhaustion
- **In-memory cache** (`createCachedFetcher`) with 5-minute TTL keyed on query string — avoids redundant API calls for the same route
- **Refresh button debounce** — button disables during in-flight fetch, re-enables on completion; prevents duplicate requests from rapid clicks

Closes #17

## Test plan

- [x] `npx vitest run src/poi-fetcher.test.ts` — 4 retry tests + 4 cache tests pass
- [x] `npx vitest run src/upload.test.ts` — 3 debounce/error tests pass
- [x] `npm run test:run` — full suite (89 tests) green
- [x] `npm run build` — TypeScript strict mode compiles cleanly
- [ ] Manual: `npm run dev`, upload GPX, click "Refresh stops" rapidly → only one request, button disabled during fetch

🤖 Generated with [Claude Code](https://claude.com/claude-code)