### PR TITLE
feat: add result card UI and auto-search on GPS fix

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,8 +25,9 @@ FuelSpot is a static single-page app (no backend) for ultra-cyclists to find ope
 
 - **`gpx-parser.ts`** — Pure function `parseGPX(gpxString) → ParsedRoute`. Handles namespace-aware XML parsing, trackpoint/routepoint extraction, haversine distance computation.
 - **`geo.ts`** — `haversine(a, b)` distance function shared across modules.
-- **`upload.ts`** — DOM layer. `initUpload()` wires up file input, persists GPX to localStorage (`fuelspot-gpx`), displays route stats.
-- **`route-map.ts`** — Leaflet map display with route visualization.
+- **`upload.ts`** — DOM layer. `initUpload()` wires up file input, persists GPX to localStorage (`fuelspot-gpx`), displays route stats. Contains `searchAndDisplay()` pipeline that fetches POIs, ranks stops, and displays the #1 result. Auto-searches on first GPS fix after route load.
+- **`result-card.ts`** — `initResultCard(container) → ResultCardHandle` renders the top-ranked stop with status badge, distance, hours, and card payment info. Handles loading, error, empty, and waiting-for-GPS states.
+- **`route-map.ts`** — Leaflet map display with route visualization, POI pins, rider position, and highlighted #1 stop.
 - **`gps-tracker.ts`** — GPS position tracking.
 - **`route-matcher.ts`** — `matchPosition(route, position)` projects a lat/lng onto the route, returning cumulative distance and on/off-route status.
 - **`poi-fetcher.ts`** — Overpass API client with retry, cache, and POI parsing. Exports `POI` type.

--- a/index.html
+++ b/index.html
@@ -27,6 +27,8 @@
       <button id="refresh-btn" type="button" hidden>Refresh stops</button>
       <p id="loading-indicator" hidden>Loading stops…</p>
 
+      <div id="result-card-container"></div>
+
       <div id="map-container"></div>
     </div>
     <script type="module" src="/src/main.ts"></script>

--- a/src/result-card.test.ts
+++ b/src/result-card.test.ts
@@ -1,0 +1,160 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { initResultCard } from './result-card';
+import type { ResultCardHandle } from './result-card';
+import type { RankedStop } from './stop-ranker';
+
+function makeStop(overrides: Partial<RankedStop> = {}): RankedStop {
+  return {
+    poi: {
+      id: 1,
+      name: 'Shell',
+      type: 'fuel',
+      lat: 50,
+      lng: 20,
+      openingHours: 'Mo-Su 06:00-22:00',
+      acceptsCards: true,
+    },
+    hours: { status: 'open', nextChange: new Date('2026-03-18T22:00:00'), displayString: 'Open until 22:00' },
+    distanceAlongRoute: 2500,
+    straightLineDistance: 2100,
+    countdown: null,
+    ...overrides,
+  };
+}
+
+describe('result-card', () => {
+  let container: HTMLElement;
+  let card: ResultCardHandle;
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    card = initResultCard(container);
+  });
+
+  // Slice 1: Init returns handle, card starts hidden
+  it('initializes with hidden wrapper', () => {
+    const wrapper = container.querySelector('.result-card') as HTMLElement;
+    expect(wrapper).not.toBeNull();
+    expect(wrapper.hidden).toBe(true);
+  });
+
+  // Slice 2: Loading state
+  it('showLoading shows searching text', () => {
+    card.showLoading();
+    const wrapper = container.querySelector('.result-card') as HTMLElement;
+    expect(wrapper.hidden).toBe(false);
+    expect(wrapper.textContent).toContain('Searching for stops...');
+  });
+
+  // Slice 3: Render open stop with all fields
+  it('showStop renders open stop with name, type, distance, hours, cards', () => {
+    card.showStop(makeStop());
+    const wrapper = container.querySelector('.result-card') as HTMLElement;
+    expect(wrapper.hidden).toBe(false);
+    expect(wrapper.textContent).toContain('Shell');
+    expect(wrapper.textContent).toContain('fuel');
+    expect(wrapper.textContent).toContain('2.5 km');
+    expect(wrapper.textContent).toContain('Open until 22:00');
+    expect(wrapper.textContent).toContain('Cards: Yes');
+  });
+
+  // Slice 4: Render closed stop with countdown
+  it('showStop renders closed stop with countdown', () => {
+    card.showStop(makeStop({
+      hours: {
+        status: 'closed',
+        nextChange: new Date('2026-03-19T06:00:00'),
+        displayString: 'Opens Thu 06:00',
+      },
+      countdown: '1h 30m',
+    }));
+    const wrapper = container.querySelector('.result-card') as HTMLElement;
+    expect(wrapper.querySelector('.badge-closed')).not.toBeNull();
+    expect(wrapper.textContent).toContain('opens in 1h 30m');
+    expect(wrapper.textContent).toContain('Opens Thu 06:00');
+  });
+
+  // Slice 5: Render unknown-hours stop
+  it('showStop renders unknown hours stop', () => {
+    card.showStop(makeStop({
+      hours: { status: 'unknown', nextChange: null, displayString: 'Hours unknown' },
+    }));
+    const wrapper = container.querySelector('.result-card') as HTMLElement;
+    expect(wrapper.textContent).toContain('Hours unknown');
+    expect(wrapper.querySelector('.badge-unknown')).not.toBeNull();
+  });
+
+  // Slice 6: Off-route distance display
+  it('shows straight line distance when not on route', () => {
+    card.showStop(makeStop({
+      distanceAlongRoute: null,
+      straightLineDistance: 1200,
+    }));
+    const wrapper = container.querySelector('.result-card') as HTMLElement;
+    expect(wrapper.textContent).toContain('1.2 km (straight line)');
+  });
+
+  // Slice 7: Null name fallback
+  it('shows Unnamed when poi name is null', () => {
+    card.showStop(makeStop({
+      poi: { id: 1, name: null, type: 'cafe', lat: 50, lng: 20, openingHours: null, acceptsCards: null },
+    }));
+    const wrapper = container.querySelector('.result-card') as HTMLElement;
+    expect(wrapper.textContent).toContain('Unnamed');
+    expect(wrapper.textContent).toContain('cafe');
+  });
+
+  // Slice 8: Card payment states
+  it('shows Unknown for null acceptsCards, No for false', () => {
+    card.showStop(makeStop({
+      poi: { id: 1, name: 'X', type: 'fuel', lat: 50, lng: 20, openingHours: null, acceptsCards: null },
+    }));
+    expect(container.textContent).toContain('Cards: Unknown');
+
+    card.showStop(makeStop({
+      poi: { id: 2, name: 'Y', type: 'fuel', lat: 50, lng: 20, openingHours: null, acceptsCards: false },
+    }));
+    expect(container.textContent).toContain('Cards: No');
+  });
+
+  // Slice 9: Error state
+  it('showError displays error text', () => {
+    card.showError('GPS denied');
+    const wrapper = container.querySelector('.result-card') as HTMLElement;
+    expect(wrapper.hidden).toBe(false);
+    expect(wrapper.textContent).toContain('GPS denied');
+  });
+
+  // Slice 10: Empty state
+  it('showEmpty displays no stops message', () => {
+    card.showEmpty();
+    const wrapper = container.querySelector('.result-card') as HTMLElement;
+    expect(wrapper.hidden).toBe(false);
+    expect(wrapper.textContent).toContain('No stops found');
+  });
+
+  // Slice 11: Waiting for GPS state
+  it('showWaitingForGps displays waiting message', () => {
+    card.showWaitingForGps();
+    const wrapper = container.querySelector('.result-card') as HTMLElement;
+    expect(wrapper.hidden).toBe(false);
+    expect(wrapper.textContent).toContain('Waiting for GPS...');
+  });
+
+  // Slice 12: Clear hides card
+  it('clear hides card after showStop', () => {
+    card.showStop(makeStop());
+    card.clear();
+    const wrapper = container.querySelector('.result-card') as HTMLElement;
+    expect(wrapper.hidden).toBe(true);
+  });
+
+  // Slice 13: Repeat showStop replaces content
+  it('second showStop replaces first', () => {
+    card.showStop(makeStop({ poi: { id: 1, name: 'First', type: 'fuel', lat: 50, lng: 20, openingHours: null, acceptsCards: null } }));
+    card.showStop(makeStop({ poi: { id: 2, name: 'Second', type: 'cafe', lat: 51, lng: 21, openingHours: null, acceptsCards: null } }));
+    const wrapper = container.querySelector('.result-card') as HTMLElement;
+    expect(wrapper.textContent).not.toContain('First');
+    expect(wrapper.textContent).toContain('Second');
+  });
+});

--- a/src/result-card.ts
+++ b/src/result-card.ts
@@ -1,0 +1,92 @@
+import type { RankedStop } from './stop-ranker';
+
+export interface ResultCardHandle {
+  showStop(stop: RankedStop): void;
+  showLoading(): void;
+  showError(message: string): void;
+  showEmpty(): void;
+  showWaitingForGps(): void;
+  clear(): void;
+}
+
+export function initResultCard(container: HTMLElement): ResultCardHandle {
+  const wrapper = document.createElement('div');
+  wrapper.className = 'result-card';
+  wrapper.hidden = true;
+  container.appendChild(wrapper);
+
+  function setContent(html: string): void {
+    wrapper.innerHTML = html;
+    wrapper.hidden = false;
+  }
+
+  function showStop(stop: RankedStop): void {
+    const name = stop.poi.name ?? 'Unnamed';
+    const type = stop.poi.type;
+
+    const distance =
+      stop.distanceAlongRoute !== null
+        ? `${(stop.distanceAlongRoute / 1000).toFixed(1)} km`
+        : `${(stop.straightLineDistance / 1000).toFixed(1)} km (straight line)`;
+
+    const statusClass = `status-${stop.hours.status}`;
+    const statusBadge =
+      stop.hours.status === 'open'
+        ? '<span class="badge badge-open">Open</span>'
+        : stop.hours.status === 'closed'
+          ? '<span class="badge badge-closed">Closed</span>'
+          : '<span class="badge badge-unknown">Unknown</span>';
+
+    const hoursLine =
+      stop.hours.status === 'unknown'
+        ? 'Hours unknown'
+        : stop.hours.displayString;
+
+    const countdownLine =
+      stop.countdown ? `<p class="result-countdown">opens in ${stop.countdown}</p>` : '';
+
+    const cards =
+      stop.poi.acceptsCards === true
+        ? 'Yes'
+        : stop.poi.acceptsCards === false
+          ? 'No'
+          : 'Unknown';
+
+    setContent(`
+      <div class="result-stop ${statusClass}">
+        <div class="result-header">
+          <h3 class="result-name">${name}</h3>
+          ${statusBadge}
+        </div>
+        <p class="result-type">${type}</p>
+        <p class="result-distance">${distance}</p>
+        <p class="result-hours">${hoursLine}</p>
+        ${countdownLine}
+        <p class="result-cards">Cards: ${cards}</p>
+      </div>
+    `);
+  }
+
+  function showLoading(): void {
+    setContent('<p class="result-loading">Searching for stops...</p>');
+  }
+
+  function showError(message: string): void {
+    setContent(`<p class="result-error">${message}</p>`);
+  }
+
+  function showEmpty(): void {
+    setContent('<p class="result-empty">No stops found nearby</p>');
+  }
+
+  function showWaitingForGps(): void {
+    setContent('<p class="result-waiting">Waiting for GPS...</p>');
+  }
+
+  function clear(): void {
+    wrapper.innerHTML = '';
+    wrapper.hidden = true;
+  }
+
+  return { showStop, showLoading, showError, showEmpty, showWaitingForGps, clear };
+}

--- a/src/route-map.test.ts
+++ b/src/route-map.test.ts
@@ -380,4 +380,47 @@ describe('route-map', () => {
     handle.showPOIs(pois2);
     expect(firstMarker.remove).toHaveBeenCalledOnce();
   });
+
+  // Slice 14: highlightStop creates distinct marker
+  it('highlightStop creates orange circleMarker with radius 10', () => {
+    const poi: POI = { id: 1, name: 'Shell', type: 'fuel', lat: 50.1, lng: 20.1, openingHours: null, acceptsCards: null };
+    handle.highlightStop(poi);
+
+    const calls = vi.mocked(mocks.factory.circleMarker).mock.calls;
+    const lastCall = calls[calls.length - 1];
+    expect(lastCall[0]).toEqual([50.1, 20.1]);
+    expect(lastCall[1]).toMatchObject({ radius: 10, color: '#f97316' });
+  });
+
+  // Slice 15: highlightStop replaces previous
+  it('highlightStop replaces previous highlight', () => {
+    const poi1: POI = { id: 1, name: 'A', type: 'fuel', lat: 50, lng: 20, openingHours: null, acceptsCards: null };
+    const poi2: POI = { id: 2, name: 'B', type: 'cafe', lat: 51, lng: 21, openingHours: null, acceptsCards: null };
+
+    handle.highlightStop(poi1);
+    const firstHighlight = mocks.circleMarkers[mocks.circleMarkers.length - 1];
+
+    handle.highlightStop(poi2);
+    expect(firstHighlight.remove).toHaveBeenCalledOnce();
+  });
+
+  // Slice 16: clearHighlight removes marker
+  it('clearHighlight removes highlight marker', () => {
+    const poi: POI = { id: 1, name: 'A', type: 'fuel', lat: 50, lng: 20, openingHours: null, acceptsCards: null };
+    handle.highlightStop(poi);
+    const highlight = mocks.circleMarkers[mocks.circleMarkers.length - 1];
+
+    handle.clearHighlight();
+    expect(highlight.remove).toHaveBeenCalledOnce();
+  });
+
+  // Slice 17: zoomToFit calls fitBounds with positions
+  it('zoomToFit calls fitBounds with given positions and padding', () => {
+    handle.zoomToFit([{ lat: 50, lng: 20 }, { lat: 51, lng: 21 }]);
+
+    expect(mocks.mockMap.fitBounds).toHaveBeenCalledWith(
+      [[50, 20], [51, 21]],
+      { padding: [50, 50] },
+    );
+  });
 });

--- a/src/route-map.ts
+++ b/src/route-map.ts
@@ -12,6 +12,9 @@ export interface RouteMapHandle {
   hideOffRouteWarning(): void;
   showPOIs(pois: POI[]): void;
   clearPOIs(): void;
+  highlightStop(poi: POI): void;
+  clearHighlight(): void;
+  zoomToFit(positions: Array<{ lat: number; lng: number }>): void;
 }
 
 export interface LeafletFactory {
@@ -207,6 +210,34 @@ export function initRouteMap(
     }
   }
 
+  let highlightMarker: L.CircleMarker | null = null;
+
+  function highlightStop(poi: POI): void {
+    clearHighlight();
+    highlightMarker = leaflet
+      .circleMarker([poi.lat, poi.lng], {
+        radius: 10,
+        color: '#f97316',
+        fillColor: '#f97316',
+        fillOpacity: 0.9,
+        weight: 3,
+      })
+      .addTo(map);
+  }
+
+  function clearHighlight(): void {
+    if (highlightMarker) {
+      highlightMarker.remove();
+      highlightMarker = null;
+    }
+  }
+
+  function zoomToFit(positions: Array<{ lat: number; lng: number }>): void {
+    if (positions.length === 0) return;
+    const bounds = positions.map((p): [number, number] => [p.lat, p.lng]);
+    map.fitBounds(bounds, { padding: [50, 50] });
+  }
+
   // Initial state: placeholder visible, map hidden
   mapDiv.hidden = true;
 
@@ -220,6 +251,9 @@ export function initRouteMap(
     hideOffRouteWarning,
     showPOIs,
     clearPOIs,
+    highlightStop,
+    clearHighlight,
+    zoomToFit,
   };
 }
 

--- a/src/style.css
+++ b/src/style.css
@@ -80,7 +80,8 @@ h1 {
   font-size: 0.9rem;
 }
 
-#clear-btn {
+#clear-btn,
+#refresh-btn {
   margin-top: 1rem;
   min-height: 44px;
   padding: 0.5rem 1.25rem;
@@ -90,6 +91,23 @@ h1 {
   font-size: 0.9rem;
   color: #666;
   cursor: pointer;
+}
+
+#refresh-btn {
+  margin-left: 0.5rem;
+  background: #2563eb;
+  color: #fff;
+  border-color: #2563eb;
+  font-weight: 500;
+}
+
+#refresh-btn:active {
+  background: #1d4ed8;
+}
+
+#refresh-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
 }
 
 #clear-btn:active {
@@ -126,4 +144,118 @@ h1 {
   font-weight: 500;
   text-align: center;
   margin-top: 0.5rem;
+}
+
+/* Result card */
+.result-card {
+  margin-top: 1rem;
+  text-align: left;
+}
+
+.result-stop {
+  padding: 1rem;
+  background: #fff;
+  border: 1px solid #e5e7eb;
+  border-radius: 0.5rem;
+}
+
+.result-stop.status-open {
+  border-left: 4px solid #22c55e;
+}
+
+.result-stop.status-closed {
+  border-left: 4px solid #dc2626;
+}
+
+.result-stop.status-unknown {
+  border-left: 4px solid #9ca3af;
+}
+
+.result-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+  margin-bottom: 0.25rem;
+}
+
+.result-name {
+  font-size: 1.125rem;
+  font-weight: 600;
+}
+
+.badge {
+  display: inline-block;
+  padding: 0.125rem 0.5rem;
+  border-radius: 1rem;
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  white-space: nowrap;
+}
+
+.badge-open {
+  background: #dcfce7;
+  color: #166534;
+}
+
+.badge-closed {
+  background: #fef2f2;
+  color: #991b1b;
+}
+
+.badge-unknown {
+  background: #f3f4f6;
+  color: #6b7280;
+}
+
+.result-type {
+  color: #666;
+  font-size: 0.85rem;
+  text-transform: capitalize;
+  margin-bottom: 0.5rem;
+}
+
+.result-distance {
+  font-size: 1.25rem;
+  font-weight: 700;
+  margin-bottom: 0.25rem;
+}
+
+.result-hours {
+  font-size: 0.9rem;
+  color: #444;
+}
+
+.result-countdown {
+  font-size: 0.85rem;
+  color: #666;
+  margin-top: 0.125rem;
+}
+
+.result-cards {
+  font-size: 0.85rem;
+  color: #666;
+  margin-top: 0.5rem;
+}
+
+.result-loading,
+.result-waiting,
+.result-empty {
+  padding: 1rem;
+  background: #f3f4f6;
+  border-radius: 0.5rem;
+  color: #666;
+  font-size: 0.9rem;
+  text-align: center;
+}
+
+.result-error {
+  padding: 1rem;
+  background: #fef2f2;
+  border: 1px solid #fecaca;
+  border-radius: 0.5rem;
+  color: #dc2626;
+  font-size: 0.9rem;
+  text-align: center;
 }

--- a/src/upload.test.ts
+++ b/src/upload.test.ts
@@ -18,6 +18,7 @@ function setupDOM(): void {
       <button id="clear-btn" type="button" hidden>Clear route</button>
       <button id="refresh-btn" type="button" hidden>Refresh stops</button>
       <p id="loading-indicator" hidden>Loading stops…</p>
+      <div id="result-card-container"></div>
       <div id="map-container"></div>
     </div>
   `;
@@ -27,7 +28,6 @@ function simulateFileUpload(content: string): void {
   const fileInput = document.getElementById('gpx-input') as HTMLInputElement;
   const file = new File([content], 'test.gpx', { type: 'application/gpx+xml' });
 
-  // Mock the files property
   Object.defineProperty(fileInput, 'files', {
     value: [file],
     writable: false,
@@ -38,7 +38,6 @@ function simulateFileUpload(content: string): void {
 }
 
 async function flushFileReader(): Promise<void> {
-  // Allow FileReader.onload to fire
   await new Promise((resolve) => setTimeout(resolve, 0));
   await new Promise((resolve) => setTimeout(resolve, 0));
 }
@@ -54,6 +53,9 @@ vi.mock('./route-map', () => {
   const hideOffRouteWarning = vi.fn();
   const showPOIs = vi.fn();
   const clearPOIs = vi.fn();
+  const highlightStop = vi.fn();
+  const clearHighlight = vi.fn();
+  const zoomToFit = vi.fn();
   return {
     initRouteMap: vi.fn(() => ({
       showRoute,
@@ -65,8 +67,26 @@ vi.mock('./route-map', () => {
       hideOffRouteWarning,
       showPOIs,
       clearPOIs,
+      highlightStop,
+      clearHighlight,
+      zoomToFit,
     })),
     setDefaultFactory: vi.fn(),
+  };
+});
+
+// Mock result-card module
+const mockResultCard = {
+  showStop: vi.fn(),
+  showLoading: vi.fn(),
+  showError: vi.fn(),
+  showEmpty: vi.fn(),
+  showWaitingForGps: vi.fn(),
+  clear: vi.fn(),
+};
+vi.mock('./result-card', () => {
+  return {
+    initResultCard: vi.fn(() => mockResultCard),
   };
 });
 
@@ -84,6 +104,33 @@ vi.mock('./poi-fetcher', () => {
       fetch: mockFetch,
       clear: vi.fn(),
     })),
+  };
+});
+
+// Mock stop-ranker module
+const mockRankStops = vi.fn().mockReturnValue([
+  {
+    poi: { id: 1, name: 'Test POI', type: 'fuel', lat: 50, lng: 20, openingHours: null, acceptsCards: null },
+    hours: { status: 'open', nextChange: null, displayString: 'Open 24/7' },
+    distanceAlongRoute: 1500,
+    straightLineDistance: 1200,
+    countdown: null,
+  },
+]);
+vi.mock('./stop-ranker', () => {
+  return {
+    rankStops: (...args: unknown[]) => mockRankStops(...args),
+  };
+});
+
+// Mock hours-evaluator module
+vi.mock('./hours-evaluator', () => {
+  return {
+    evaluateHours: vi.fn().mockReturnValue({ status: 'unknown', nextChange: null, displayString: 'Hours unknown' }),
+    createOpeningHoursParser: vi.fn(() => ({
+      evaluate: vi.fn().mockReturnValue({ isOpen: false, isUnknown: true, nextChange: null }),
+    })),
+    formatCountdown: vi.fn().mockReturnValue('1h 30m'),
   };
 });
 
@@ -314,40 +361,61 @@ describe('upload refresh button', () => {
     expect(refreshBtn.hidden).toBe(true);
   });
 
-  // Slice 13: Refresh button triggers POI fetch and displays results on map
-  it('clicking refresh fetches POIs and shows on map', async () => {
+  // Slice 13: Refresh button triggers search pipeline when GPS available
+  it('clicking refresh with GPS runs search pipeline', async () => {
     const { initRouteMap } = await import('./route-map');
-    initUpload();
+    const mockGeo = createMockGeo();
+    initUpload(mockGeo.geo);
     const handle = vi.mocked(initRouteMap).mock.results[0].value;
 
     simulateFileUpload(MINIMAL_2_TRKPT);
     await flushFileReader();
 
+    // Give GPS position first
+    mockGeo.simulatePosition(50, 20);
+    // Wait for auto-search to complete
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    // Reset mocks after auto-search
+    vi.clearAllMocks();
+    mockFetch.mockResolvedValue([
+      { id: 1, name: 'Test POI', type: 'fuel', lat: 50, lng: 20, openingHours: null, acceptsCards: null },
+    ]);
+    mockRankStops.mockReturnValue([
+      {
+        poi: { id: 1, name: 'Test POI', type: 'fuel', lat: 50, lng: 20, openingHours: null, acceptsCards: null },
+        hours: { status: 'open', nextChange: null, displayString: 'Open 24/7' },
+        distanceAlongRoute: 1500,
+        straightLineDistance: 1200,
+        countdown: null,
+      },
+    ]);
+
     const refreshBtn = document.getElementById('refresh-btn') as HTMLButtonElement;
     refreshBtn.click();
 
-    // Wait for async fetch
     await new Promise((resolve) => setTimeout(resolve, 0));
 
     expect(mockFetch).toHaveBeenCalledOnce();
+    expect(mockRankStops).toHaveBeenCalledOnce();
+    expect(mockResultCard.showStop).toHaveBeenCalledOnce();
+    expect(handle.highlightStop).toHaveBeenCalledOnce();
     expect(handle.showPOIs).toHaveBeenCalledOnce();
   });
 
   // Slice 14: Loading indicator shown during fetch, hidden after
   it('shows loading indicator during fetch', async () => {
-    initUpload();
-    const loading = document.getElementById('loading-indicator') as HTMLElement;
+    const mockGeo = createMockGeo();
+    initUpload(mockGeo.geo);
 
     simulateFileUpload(MINIMAL_2_TRKPT);
     await flushFileReader();
+    mockGeo.simulatePosition(50, 20);
 
-    expect(loading.hidden).toBe(true);
-
-    const refreshBtn = document.getElementById('refresh-btn') as HTMLButtonElement;
-    refreshBtn.click();
-
-    // Loading should eventually be hidden after fetch completes
+    // Wait for auto-search to finish
     await new Promise((resolve) => setTimeout(resolve, 0));
+
+    const loading = document.getElementById('loading-indicator') as HTMLElement;
     expect(loading.hidden).toBe(true);
   });
 
@@ -355,21 +423,19 @@ describe('upload refresh button', () => {
   it('shows error on fetch failure and hides loading', async () => {
     mockFetch.mockRejectedValueOnce(new Error('Overpass API error'));
 
-    initUpload();
+    const mockGeo = createMockGeo();
+    initUpload(mockGeo.geo);
 
     simulateFileUpload(MINIMAL_2_TRKPT);
     await flushFileReader();
 
-    const refreshBtn = document.getElementById('refresh-btn') as HTMLButtonElement;
-    refreshBtn.click();
+    mockGeo.simulatePosition(50, 20);
 
     await new Promise((resolve) => setTimeout(resolve, 0));
 
     const loading = document.getElementById('loading-indicator') as HTMLElement;
-    const errorDisplay = document.getElementById('error-display') as HTMLElement;
     expect(loading.hidden).toBe(true);
-    expect(errorDisplay.hidden).toBe(false);
-    expect(errorDisplay.textContent).toContain('Overpass API error');
+    expect(mockResultCard.showError).toHaveBeenCalled();
   });
 
   // Cycle 3: Debounce — two clicks while in-flight only fetches once
@@ -379,18 +445,21 @@ describe('upload refresh button', () => {
       () => new Promise((resolve) => { resolveFetch = resolve; }),
     );
 
-    initUpload();
+    const mockGeo = createMockGeo();
+    initUpload(mockGeo.geo);
 
     simulateFileUpload(MINIMAL_2_TRKPT);
     await flushFileReader();
 
-    const refreshBtn = document.getElementById('refresh-btn') as HTMLButtonElement;
-    refreshBtn.click(); // first click — starts fetch
-    refreshBtn.click(); // second click — should be ignored
+    mockGeo.simulatePosition(50, 20);
 
+    // auto-search is in flight, click refresh
+    const refreshBtn = document.getElementById('refresh-btn') as HTMLButtonElement;
+    refreshBtn.click();
+
+    // Should still be just 1 fetch (auto-search)
     expect(mockFetch).toHaveBeenCalledTimes(1);
 
-    // Complete the fetch
     resolveFetch([]);
     await new Promise((resolve) => setTimeout(resolve, 0));
   });
@@ -402,14 +471,16 @@ describe('upload refresh button', () => {
       () => new Promise((resolve) => { resolveFetch = resolve; }),
     );
 
-    initUpload();
+    const mockGeo = createMockGeo();
+    initUpload(mockGeo.geo);
 
     simulateFileUpload(MINIMAL_2_TRKPT);
     await flushFileReader();
 
-    const refreshBtn = document.getElementById('refresh-btn') as HTMLButtonElement;
-    refreshBtn.click();
+    mockGeo.simulatePosition(50, 20);
 
+    // auto-search in flight — button should be disabled
+    const refreshBtn = document.getElementById('refresh-btn') as HTMLButtonElement;
     expect(refreshBtn.disabled).toBe(true);
 
     resolveFetch([]);
@@ -424,7 +495,116 @@ describe('upload refresh button', () => {
       new Error('Failed to fetch POIs: Overpass API is busy — please try again in a minute'),
     );
 
+    const mockGeo = createMockGeo();
+    initUpload(mockGeo.geo);
+
+    simulateFileUpload(MINIMAL_2_TRKPT);
+    await flushFileReader();
+
+    mockGeo.simulatePosition(50, 20);
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(mockResultCard.showError).toHaveBeenCalledWith(
+      expect.stringContaining('try again'),
+    );
+  });
+});
+
+describe('upload auto-search pipeline', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    setupDOM();
+    vi.clearAllMocks();
+    mockFetch.mockResolvedValue([
+      { id: 1, name: 'Test POI', type: 'fuel', lat: 50, lng: 20, openingHours: null, acceptsCards: null },
+    ]);
+    mockRankStops.mockReturnValue([
+      {
+        poi: { id: 1, name: 'Test POI', type: 'fuel', lat: 50, lng: 20, openingHours: null, acceptsCards: null },
+        hours: { status: 'open', nextChange: null, displayString: 'Open 24/7' },
+        distanceAlongRoute: 1500,
+        straightLineDistance: 1200,
+        countdown: null,
+      },
+    ]);
+  });
+
+  // Slice 18: Result card initialized on init
+  it('initializes result card on init', async () => {
+    const { initResultCard } = await import('./result-card');
     initUpload();
+
+    expect(initResultCard).toHaveBeenCalledOnce();
+  });
+
+  // Slice 19: Route loaded without GPS shows "waiting for GPS"
+  it('shows waiting for GPS when route loaded without GPS position', async () => {
+    const mockGeo = createMockGeo();
+    initUpload(mockGeo.geo);
+
+    simulateFileUpload(MINIMAL_2_TRKPT);
+    await flushFileReader();
+
+    expect(mockResultCard.showWaitingForGps).toHaveBeenCalled();
+  });
+
+  // Slice 20: Auto-search fires on first GPS position
+  it('auto-search fires on first GPS position after route load', async () => {
+    const { initRouteMap } = await import('./route-map');
+    const mockGeo = createMockGeo();
+    initUpload(mockGeo.geo);
+    const handle = vi.mocked(initRouteMap).mock.results[0].value;
+
+    simulateFileUpload(MINIMAL_2_TRKPT);
+    await flushFileReader();
+
+    mockGeo.simulatePosition(50, 20);
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(mockFetch).toHaveBeenCalledOnce();
+    expect(mockRankStops).toHaveBeenCalledOnce();
+    expect(mockResultCard.showStop).toHaveBeenCalledOnce();
+    expect(handle.highlightStop).toHaveBeenCalledOnce();
+  });
+
+  // Slice 21: Auto-search doesn't re-trigger on subsequent GPS updates
+  it('auto-search fires only once', async () => {
+    const mockGeo = createMockGeo();
+    initUpload(mockGeo.geo);
+
+    simulateFileUpload(MINIMAL_2_TRKPT);
+    await flushFileReader();
+
+    mockGeo.simulatePosition(50, 20);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    mockGeo.simulatePosition(50.001, 20.001);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+  });
+
+  // Slice 22: GPS denied shows error on result card
+  it('GPS denied shows error on result card', async () => {
+    const mockGeo = createMockGeo();
+    initUpload(mockGeo.geo);
+
+    simulateFileUpload(MINIMAL_2_TRKPT);
+    await flushFileReader();
+
+    mockGeo.simulateError(1);
+
+    expect(mockResultCard.showError).toHaveBeenCalledWith(
+      expect.stringContaining('GPS'),
+    );
+  });
+
+  // Slice 23: Refresh without GPS shows GPS warning
+  it('refresh without GPS shows GPS warning on result card', async () => {
+    const mockGeo = createMockGeo();
+    initUpload(mockGeo.geo);
 
     simulateFileUpload(MINIMAL_2_TRKPT);
     await flushFileReader();
@@ -432,9 +612,148 @@ describe('upload refresh button', () => {
     const refreshBtn = document.getElementById('refresh-btn') as HTMLButtonElement;
     refreshBtn.click();
 
+    expect(mockResultCard.showError).toHaveBeenCalledWith(
+      expect.stringContaining('GPS'),
+    );
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  // Slice 25: Pipeline shows loading on card
+  it('pipeline shows loading on card before fetch', async () => {
+    const mockGeo = createMockGeo();
+    initUpload(mockGeo.geo);
+
+    simulateFileUpload(MINIMAL_2_TRKPT);
+    await flushFileReader();
+
+    mockGeo.simulatePosition(50, 20);
+
+    expect(mockResultCard.showLoading).toHaveBeenCalled();
+  });
+
+  // Slice 26: Empty ranking shows "no stops"
+  it('empty ranking shows no stops on card', async () => {
+    mockRankStops.mockReturnValue([]);
+
+    const mockGeo = createMockGeo();
+    initUpload(mockGeo.geo);
+
+    simulateFileUpload(MINIMAL_2_TRKPT);
+    await flushFileReader();
+
+    mockGeo.simulatePosition(50, 20);
     await new Promise((resolve) => setTimeout(resolve, 0));
 
-    const errorDisplay = document.getElementById('error-display') as HTMLElement;
-    expect(errorDisplay.textContent).toContain('try again');
+    expect(mockResultCard.showEmpty).toHaveBeenCalled();
+  });
+
+  // Slice 27: Fetch error shows error on card
+  it('fetch error shows error on card', async () => {
+    mockFetch.mockRejectedValue(new Error('Network error'));
+
+    const mockGeo = createMockGeo();
+    initUpload(mockGeo.geo);
+
+    simulateFileUpload(MINIMAL_2_TRKPT);
+    await flushFileReader();
+
+    mockGeo.simulatePosition(50, 20);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(mockResultCard.showError).toHaveBeenCalledWith(
+      expect.stringContaining('Network error'),
+    );
+  });
+
+  // Slice 28: Pipeline highlights #1 on map
+  it('pipeline highlights #1 stop on map', async () => {
+    const { initRouteMap } = await import('./route-map');
+    const mockGeo = createMockGeo();
+    initUpload(mockGeo.geo);
+    const handle = vi.mocked(initRouteMap).mock.results[0].value;
+
+    simulateFileUpload(MINIMAL_2_TRKPT);
+    await flushFileReader();
+
+    mockGeo.simulatePosition(50, 20);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(handle.highlightStop).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 1, name: 'Test POI' }),
+    );
+  });
+
+  // Slice 29: Pipeline zooms map to rider + #1 stop
+  it('pipeline zooms map to rider and #1 stop', async () => {
+    const { initRouteMap } = await import('./route-map');
+    const mockGeo = createMockGeo();
+    initUpload(mockGeo.geo);
+    const handle = vi.mocked(initRouteMap).mock.results[0].value;
+
+    simulateFileUpload(MINIMAL_2_TRKPT);
+    await flushFileReader();
+
+    mockGeo.simulatePosition(50, 20);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(handle.zoomToFit).toHaveBeenCalledWith([
+      { lat: 50, lng: 20 },
+      { lat: 50, lng: 20 },
+    ]);
+  });
+
+  // Slice 30: Clear resets card and highlight
+  it('clear resets result card and map highlight', async () => {
+    const { initRouteMap } = await import('./route-map');
+    const mockGeo = createMockGeo();
+    initUpload(mockGeo.geo);
+    const handle = vi.mocked(initRouteMap).mock.results[0].value;
+
+    simulateFileUpload(MINIMAL_2_TRKPT);
+    await flushFileReader();
+
+    const clearBtn = document.getElementById('clear-btn') as HTMLButtonElement;
+    clearBtn.click();
+
+    expect(mockResultCard.clear).toHaveBeenCalled();
+    expect(handle.clearHighlight).toHaveBeenCalled();
+  });
+
+  // Slice 31: New file upload resets auto-search flag
+  it('new file upload resets auto-search flag', async () => {
+    const mockGeo = createMockGeo();
+    initUpload(mockGeo.geo);
+
+    simulateFileUpload(MINIMAL_2_TRKPT);
+    await flushFileReader();
+
+    mockGeo.simulatePosition(50, 20);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+
+    // Upload new file
+    vi.clearAllMocks();
+    mockFetch.mockResolvedValue([
+      { id: 2, name: 'New POI', type: 'cafe', lat: 51, lng: 21, openingHours: null, acceptsCards: null },
+    ]);
+    mockRankStops.mockReturnValue([
+      {
+        poi: { id: 2, name: 'New POI', type: 'cafe', lat: 51, lng: 21, openingHours: null, acceptsCards: null },
+        hours: { status: 'open', nextChange: null, displayString: 'Open 24/7' },
+        distanceAlongRoute: 2000,
+        straightLineDistance: 1500,
+        countdown: null,
+      },
+    ]);
+
+    simulateFileUpload(MINIMAL_2_TRKPT);
+    await flushFileReader();
+
+    // GPS arrives again — should trigger auto-search again
+    mockGeo.simulatePosition(50, 20);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/upload.ts
+++ b/src/upload.ts
@@ -2,9 +2,14 @@ import { parseGPX } from './gpx-parser';
 import type { ParsedRoute } from './gpx-parser';
 import { initRouteMap } from './route-map';
 import { initGpsTracker } from './gps-tracker';
-import type { GeolocationProvider, GpsTrackerHandle } from './gps-tracker';
+import type { GeolocationProvider, GpsTrackerHandle, GpsState } from './gps-tracker';
 import { createOverpassClient, createCachedFetcher } from './poi-fetcher';
 import type { OverpassClient } from './poi-fetcher';
+import { initResultCard } from './result-card';
+import { rankStops } from './stop-ranker';
+import { evaluateHours, createOpeningHoursParser } from './hours-evaluator';
+import { matchPosition } from './route-matcher';
+import { haversine } from './geo';
 
 const STORAGE_KEY = 'fuelspot-gpx';
 
@@ -19,35 +24,111 @@ export function initUpload(geo?: GeolocationProvider, overpassClient?: OverpassC
   const pointCount = document.getElementById('point-count') as HTMLElement;
   const routeDistance = document.getElementById('route-distance') as HTMLElement;
   const mapContainer = document.getElementById('map-container') as HTMLElement;
+  const resultCardContainer = document.getElementById('result-card-container') as HTMLElement;
 
   const mapHandle = initRouteMap(mapContainer);
+  const resultCard = initResultCard(resultCardContainer);
   const client = overpassClient ?? createOverpassClient();
   const cachedFetcher = createCachedFetcher(client);
+  const hoursParser = createOpeningHoursParser();
 
   let gpsTracker: GpsTrackerHandle | null = null;
   let currentRoute: ParsedRoute | null = null;
+  let hasAutoSearched = false;
+  let pipelineInFlight = false;
 
   const geoProvider = geo ?? (typeof navigator !== 'undefined' && navigator.geolocation
     ? navigator.geolocation
     : null);
 
+  function onGpsChange(state: GpsState): void {
+    if (state.position) {
+      mapHandle.showRiderPosition(state.position);
+    }
+    if (state.match) {
+      if (state.match.isOnRoute) {
+        mapHandle.hideOffRouteWarning();
+      } else {
+        mapHandle.showOffRouteWarning();
+      }
+    }
+
+    if (state.error === 'denied' && currentRoute) {
+      resultCard.showError('GPS access denied — enable location to find stops');
+      return;
+    }
+
+    if (state.position && currentRoute && !hasAutoSearched) {
+      hasAutoSearched = true;
+      searchAndDisplay();
+    }
+  }
+
   if (geoProvider) {
-    gpsTracker = initGpsTracker(geoProvider, (state) => {
-      if (state.position) {
-        mapHandle.showRiderPosition(state.position);
+    gpsTracker = initGpsTracker(geoProvider, onGpsChange);
+  }
+
+  async function searchAndDisplay(): Promise<void> {
+    if (!currentRoute || pipelineInFlight) return;
+
+    const gpsState = gpsTracker?.getState();
+    if (!gpsState?.position) {
+      resultCard.showError('GPS position not available — enable location to find stops');
+      return;
+    }
+
+    pipelineInFlight = true;
+    refreshBtn.disabled = true;
+    resultCard.showLoading();
+    loadingIndicator.hidden = false;
+    errorSection.hidden = true;
+
+    try {
+      const pois = await cachedFetcher.fetch(currentRoute.points);
+
+      const gpsStateNow = gpsTracker!.getState();
+      const position = gpsStateNow.position ?? gpsState.position;
+      const match = gpsStateNow.match ?? matchPosition(currentRoute.points, position);
+
+      const ranked = rankStops(
+        {
+          pois,
+          route: currentRoute.points,
+          riderMatch: match,
+          riderPosition: position,
+          at: new Date(),
+        },
+        {
+          evaluateHours: (oh, at) => evaluateHours(oh, at, hoursParser),
+          matchPosition,
+          haversine,
+        },
+      );
+
+      mapHandle.showPOIs(pois);
+
+      if (ranked.length === 0) {
+        resultCard.showEmpty();
+        mapHandle.clearHighlight();
+      } else {
+        const top = ranked[0];
+        resultCard.showStop(top);
+        mapHandle.highlightStop(top.poi);
+        mapHandle.zoomToFit([position, { lat: top.poi.lat, lng: top.poi.lng }]);
       }
-      if (state.match) {
-        if (state.match.isOnRoute) {
-          mapHandle.hideOffRouteWarning();
-        } else {
-          mapHandle.showOffRouteWarning();
-        }
-      }
-    });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Failed to load stops';
+      resultCard.showError(message);
+    } finally {
+      loadingIndicator.hidden = true;
+      refreshBtn.disabled = false;
+      pipelineInFlight = false;
+    }
   }
 
   function showRoute(route: ParsedRoute): void {
     currentRoute = route;
+    hasAutoSearched = false;
     routeName.textContent = route.name ?? 'Unnamed route';
     pointCount.textContent = `${route.points.length} points`;
     routeDistance.textContent = `${(route.totalDistance / 1000).toFixed(1)} km`;
@@ -57,6 +138,10 @@ export function initUpload(geo?: GeolocationProvider, overpassClient?: OverpassC
     refreshBtn.hidden = false;
     mapHandle.showRoute(route);
     gpsTracker?.start(route.points);
+
+    if (geoProvider) {
+      resultCard.showWaitingForGps();
+    }
   }
 
   function showError(message: string): void {
@@ -67,6 +152,7 @@ export function initUpload(geo?: GeolocationProvider, overpassClient?: OverpassC
 
   function resetUI(): void {
     currentRoute = null;
+    hasAutoSearched = false;
     statsSection.hidden = true;
     errorSection.hidden = true;
     clearBtn.hidden = true;
@@ -74,6 +160,8 @@ export function initUpload(geo?: GeolocationProvider, overpassClient?: OverpassC
     fileInput.value = '';
     mapHandle.clear();
     mapHandle.clearPOIs();
+    mapHandle.clearHighlight();
+    resultCard.clear();
     gpsTracker?.stop();
     mapHandle.clearRiderPosition();
     mapHandle.hideOffRouteWarning();
@@ -115,20 +203,13 @@ export function initUpload(geo?: GeolocationProvider, overpassClient?: OverpassC
 
   refreshBtn.addEventListener('click', () => {
     if (!currentRoute || refreshBtn.disabled) return;
-    refreshBtn.disabled = true;
-    loadingIndicator.hidden = false;
-    errorSection.hidden = true;
 
-    cachedFetcher.fetch(currentRoute.points)
-      .then((pois) => {
-        mapHandle.showPOIs(pois);
-      })
-      .catch((err) => {
-        showError(err instanceof Error ? err.message : 'Failed to load stops');
-      })
-      .finally(() => {
-        loadingIndicator.hidden = true;
-        refreshBtn.disabled = false;
-      });
+    const gpsState = gpsTracker?.getState();
+    if (!gpsState?.position) {
+      resultCard.showError('GPS position not available — enable location to find stops');
+      return;
+    }
+
+    searchAndDisplay();
   });
 }


### PR DESCRIPTION
## Summary

- Add `result-card.ts` module that renders the top-ranked stop with status badge (open/closed/unknown), distance, hours, countdown, and card payment info
- Extend `route-map.ts` with `highlightStop()`, `clearHighlight()`, and `zoomToFit()` methods
- Wire `upload.ts` with a `searchAndDisplay()` pipeline: fetch POIs → rank stops → show #1 result on card + highlight on map + zoom to fit
- Auto-search triggers on first GPS position after route load; "Waiting for GPS..." shown until then
- Refresh button re-runs the pipeline; GPS is required (shows error if unavailable)
- Add result card container to `index.html` and styles to `style.css` with status color coding

## Test plan

- [x] `npm run test:run` — all 144 tests pass (13 new result-card, 4 new route-map, 14 new upload pipeline)
- [x] `npm run build` — TypeScript strict mode passes, no unused vars
- [ ] Manual: open dev server, upload GPX → "Waiting for GPS..." shown
- [ ] Manual: allow GPS → auto-search fires, result card shows #1 stop
- [ ] Manual: map zooms to show rider + nearest stop
- [ ] Manual: deny GPS → error message on result card
- [ ] Manual: click refresh → re-runs pipeline
- [ ] Manual: verify mobile layout (480px)

Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)