### PR TITLE
feat: retry Overpass API 5xx errors

### DIFF
--- a/src/poi-fetcher.test.ts
+++ b/src/poi-fetcher.test.ts
@@ -262,7 +262,37 @@ describe('createOverpassClient retry', () => {
     vi.unstubAllGlobals();
   });
 
-  it('rejects immediately on non-429 errors without retry', async () => {
+  it('retries on 504 then resolves with data', async () => {
+    const mockFetch = vi.fn()
+      .mockResolvedValueOnce({ ok: false, status: 504 })
+      .mockResolvedValueOnce({ ok: false, status: 504 })
+      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve(validResponse) });
+    vi.stubGlobal('fetch', mockFetch);
+
+    const client = createOverpassClient({ delayFn: noDelay });
+    const result = await client.query('test');
+
+    expect(result).toEqual(validResponse);
+    expect(mockFetch).toHaveBeenCalledTimes(3);
+
+    vi.unstubAllGlobals();
+  });
+
+  it('rejects with friendly message after 5xx retries exhausted', async () => {
+    const mockFetch = vi.fn().mockResolvedValue({ ok: false, status: 504 });
+    vi.stubGlobal('fetch', mockFetch);
+
+    const client = createOverpassClient({ maxRetries: 3, delayFn: noDelay });
+
+    await expect(client.query('test')).rejects.toThrow(
+      'Server timed out — please try again',
+    );
+    expect(mockFetch).toHaveBeenCalledTimes(4); // 1 initial + 3 retries
+
+    vi.unstubAllGlobals();
+  });
+
+  it('rejects immediately on non-retryable errors without retry', async () => {
     const mockFetch = vi.fn().mockResolvedValue({ ok: false, status: 500 });
     vi.stubGlobal('fetch', mockFetch);
 

--- a/src/poi-fetcher.ts
+++ b/src/poi-fetcher.ts
@@ -131,6 +131,11 @@ export interface OverpassClientOptions {
 
 const defaultDelay = (ms: number) => new Promise<void>((r) => setTimeout(r, ms));
 
+const RETRYABLE_STATUSES = [429, 502, 503, 504];
+function isRetryableStatus(status: number): boolean {
+  return RETRYABLE_STATUSES.includes(status);
+}
+
 export function createOverpassClient(options?: OverpassClientOptions): OverpassClient {
   const maxRetries = options?.maxRetries ?? 3;
   const baseDelay = options?.baseDelay ?? 1000;
@@ -146,9 +151,12 @@ export function createOverpassClient(options?: OverpassClientOptions): OverpassC
           headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
         });
         if (res.ok) return res.json();
-        if (res.status !== 429 || retries >= maxRetries) {
+        if (!isRetryableStatus(res.status) || retries >= maxRetries) {
           if (res.status === 429) {
             throw new Error('Overpass API is busy — please try again in a minute');
+          }
+          if (res.status >= 502 && res.status <= 504) {
+            throw new Error('Server timed out — please try again');
           }
           throw new Error(`Overpass API error: ${res.status}`);
         }


### PR DESCRIPTION
## Summary
- Extend Overpass API retry logic to cover 502/503/504 gateway errors (previously only 429 was retried)
- Show friendly "Server timed out — please try again" message when 5xx retries are exhausted
- Extract `isRetryableStatus` helper for clean status checking

Closes #34

## Test plan
- [x] New test: 504 twice then 200 → retries and resolves
- [x] New test: all attempts return 504 → throws friendly timeout message
- [x] Existing test: non-retryable 500 still fails immediately
- [x] Existing 429 retry tests still pass
- [x] Build passes