### PR TITLE
feat: make GPS tracker route optional

### DIFF
--- a/src/gps-tracker.test.ts
+++ b/src/gps-tracker.test.ts
@@ -151,4 +151,28 @@ describe('gps-tracker', () => {
     expect(state.match).toBeNull();
     expect(state.error).toBeNull();
   });
+
+  // #38: GPS tracker optional route support
+  it('emits position with null match when started without route', () => {
+    handle.start();
+    mockGeo.simulatePosition(50, 20.01);
+
+    expect(onChange).toHaveBeenCalledOnce();
+    const state: GpsState = onChange.mock.calls[0][0];
+    expect(state.position).toEqual({ lat: 50, lng: 20.01 });
+    expect(state.match).toBeNull();
+    expect(state.error).toBeNull();
+  });
+
+  it('matches route after restarting with route points', () => {
+    handle.start();
+    mockGeo.simulatePosition(50, 20.01);
+
+    handle.start(straightRoute());
+    mockGeo.simulatePosition(50, 20.02);
+
+    const state: GpsState = onChange.mock.calls[1][0];
+    expect(state.match).not.toBeNull();
+    expect(state.match!.isOnRoute).toBe(true);
+  });
 });

--- a/src/gps-tracker.ts
+++ b/src/gps-tracker.ts
@@ -18,7 +18,7 @@ export interface GpsState {
 }
 
 export interface GpsTrackerHandle {
-  start(route: RoutePoint[]): void;
+  start(route?: RoutePoint[]): void;
   stop(): void;
   getState(): GpsState;
 }
@@ -34,13 +34,12 @@ export function initGpsTracker(
 
   function handlePosition(pos: GeolocationPosition): void {
     const position = { lat: pos.coords.latitude, lng: pos.coords.longitude };
-    const match = matchPosition(route, position, lastKnownIndex);
-
-    if (
-      lastKnownIndex === undefined ||
-      match.nearestPointIndex >= lastKnownIndex
-    ) {
-      lastKnownIndex = match.nearestPointIndex;
+    let match: MatchResult | null = null;
+    if (route.length > 0) {
+      match = matchPosition(route, position, lastKnownIndex);
+      if (lastKnownIndex === undefined || match.nearestPointIndex >= lastKnownIndex) {
+        lastKnownIndex = match.nearestPointIndex;
+      }
     }
 
     state = { position, match, error: null };
@@ -57,11 +56,11 @@ export function initGpsTracker(
     onChange(state);
   }
 
-  function start(newRoute: RoutePoint[]): void {
+  function start(newRoute?: RoutePoint[]): void {
     if (watchId !== null) {
       geo.clearWatch(watchId);
     }
-    route = newRoute;
+    route = newRoute ?? [];
     lastKnownIndex = undefined;
     state = { position: null, match: null, error: null };
     watchId = geo.watchPosition(handlePosition, handleError, {


### PR DESCRIPTION
## Summary

- Make `start(route?)` optional in `GpsTrackerHandle` so the GPS tracker can emit raw position updates (`match: null`) without a loaded GPX route
- Guard `matchPosition` behind `route.length > 0` — when no route is provided, positions are emitted with `match: null`
- Fully backward-compatible: existing call site in `upload.ts` is unaffected

Closes #38

## Test plan

- [x] New test: `start()` without route emits position with `match: null`
- [x] New test: restarting with route after routeless start produces real match
- [x] All 211 existing tests pass
- [x] `npm run build` compiles cleanly